### PR TITLE
removed leading space from hex codes

### DIFF
--- a/json/colorhouse.json
+++ b/json/colorhouse.json
@@ -1,641 +1,641 @@
 [
   {
-    "hex": " #ffffff",
+    "hex": "#ffffff",
     "label": "Bisque-01",
     "name": "Bisque .01"
   },
   {
-    "hex": " #f8faf8",
+    "hex": "#f8faf8",
     "label": "Imagine-01",
     "name": "Imagine .01"
   },
   {
-    "hex": " #fafdf4",
+    "hex": "#fafdf4",
     "label": "Imagine-02",
     "name": "Imagine .02"
   },
   {
-    "hex": " #f4f8e7",
+    "hex": "#f4f8e7",
     "label": "Imagine-03",
     "name": "Imagine .03"
   },
   {
-    "hex": " #f0eddb",
+    "hex": "#f0eddb",
     "label": "Imagine-04",
     "name": "Imagine .04"
   },
   {
-    "hex": " #f0f2f1",
+    "hex": "#f0f2f1",
     "label": "Imagine-05",
     "name": "Imagine .05"
   },
   {
-    "hex": " #eae9e1",
+    "hex": "#eae9e1",
     "label": "Imagine-06",
     "name": "Imagine .06"
   },
   {
-    "hex": " #f0eee2",
+    "hex": "#f0eee2",
     "label": "Bisque-02",
     "name": "Bisque .02"
   },
   {
-    "hex": " #e4e2d3",
+    "hex": "#e4e2d3",
     "label": "Bisque-03",
     "name": "Bisque .03"
   },
   {
-    "hex": " #fbf8e7",
+    "hex": "#fbf8e7",
     "label": "Air-01",
     "name": "Air .01"
   },
   {
-    "hex": " #ece6d1",
+    "hex": "#ece6d1",
     "label": "Air-02",
     "name": "Air .02"
   },
   {
-    "hex": " #e5dfc9",
+    "hex": "#e5dfc9",
     "label": "Air-03",
     "name": "Air .03"
   },
   {
-    "hex": " #d9d9c8",
+    "hex": "#d9d9c8",
     "label": "Bisque-05",
     "name": "Bisque .05"
   },
   {
-    "hex": " #e7fced",
+    "hex": "#e7fced",
     "label": "Air-05",
     "name": "Air .05"
   },
   {
-    "hex": " #d7e2e5",
+    "hex": "#d7e2e5",
     "label": "Air-06",
     "name": "Air .06"
   },
   {
-    "hex": " #e0ede6",
+    "hex": "#e0ede6",
     "label": "Bisque-04",
     "name": "Bisque .04"
   },
   {
-    "hex": " #dae2dd",
+    "hex": "#dae2dd",
     "label": "Bisque-06",
     "name": "Bisque .06"
   },
   {
-    "hex": " #f8e7c9",
+    "hex": "#f8e7c9",
     "label": "Create-01",
     "name": "Create .01"
   },
   {
-    "hex": " #fff5d1",
+    "hex": "#fff5d1",
     "label": "Air-04",
     "name": "Air .04"
   },
   {
-    "hex": " #fef2c2",
+    "hex": "#fef2c2",
     "label": "Sprout-04",
     "name": "Sprout .04"
   },
   {
-    "hex": " #fff0c2",
+    "hex": "#fff0c2",
     "label": "Grain-01",
     "name": "Grain .01"
   },
   {
-    "hex": " #f4dea8",
+    "hex": "#f4dea8",
     "label": "Grain-02",
     "name": "Grain .02"
   },
   {
-    "hex": " #e9d19e",
+    "hex": "#e9d19e",
     "label": "Grain-03",
     "name": "Grain .03"
   },
   {
-    "hex": " #e1c9a1",
+    "hex": "#e1c9a1",
     "label": "Grain-04",
     "name": "Grain .04"
   },
   {
-    "hex": " #dfbd87",
+    "hex": "#dfbd87",
     "label": "Grain-05",
     "name": "Grain .05"
   },
   {
-    "hex": " #ca9f5e",
+    "hex": "#ca9f5e",
     "label": "Grain-06",
     "name": "Grain .06"
   },
   {
-    "hex": " #af8a3a",
+    "hex": "#af8a3a",
     "label": "Grain-07",
     "name": "Grain .07"
   },
   {
-    "hex": " #fbefbb",
+    "hex": "#fbefbb",
     "label": "Aspire-01",
     "name": "Aspire .01"
   },
   {
-    "hex": " #fae39f",
+    "hex": "#fae39f",
     "label": "Aspire-02",
     "name": "Aspire .02"
   },
   {
-    "hex": " #eeda9c",
+    "hex": "#eeda9c",
     "label": "Aspire-03",
     "name": "Aspire .03"
   },
   {
-    "hex": " #f0d181",
+    "hex": "#f0d181",
     "label": "Aspire-04",
     "name": "Aspire .04"
   },
   {
-    "hex": " #eabe5b",
+    "hex": "#eabe5b",
     "label": "Aspire-05",
     "name": "Aspire .05"
   },
   {
-    "hex": " #ffba38",
+    "hex": "#ffba38",
     "label": "Aspire-06",
     "name": "Aspire .06"
   },
   {
-    "hex": " #edd79a",
+    "hex": "#edd79a",
     "label": "Beeswax-01",
     "name": "Beeswax .01"
   },
   {
-    "hex": " #e9d095",
+    "hex": "#e9d095",
     "label": "Beeswax-02",
     "name": "Beeswax .02"
   },
   {
-    "hex": " #ceaa5b",
+    "hex": "#ceaa5b",
     "label": "Beeswax-03",
     "name": "Beeswax .03"
   },
   {
-    "hex": " #e0cd74",
+    "hex": "#e0cd74",
     "label": "Beeswax-04",
     "name": "Beeswax .04"
   },
   {
-    "hex": " #c9b156",
+    "hex": "#c9b156",
     "label": "Beeswax-05",
     "name": "Beeswax .05"
   },
   {
-    "hex": " #b29445",
+    "hex": "#b29445",
     "label": "Beeswax-06",
     "name": "Beeswax .06"
   },
   {
-    "hex": " #d2d1ad",
+    "hex": "#d2d1ad",
     "label": "Leaf-01",
     "name": "Leaf .01"
   },
   {
-    "hex": " #c1b98f",
+    "hex": "#c1b98f",
     "label": "Leaf-02",
     "name": "Leaf .02"
   },
   {
-    "hex": " #c9cdbf",
+    "hex": "#c9cdbf",
     "label": "Leaf-03",
     "name": "Leaf .03"
   },
   {
-    "hex": " #d0d3b2",
+    "hex": "#d0d3b2",
     "label": "Glass-01",
     "name": "Glass .01"
   },
   {
-    "hex": " #c9cfb5",
+    "hex": "#c9cfb5",
     "label": "Glass-02",
     "name": "Glass .02"
   },
   {
-    "hex": " #b9ba99",
+    "hex": "#b9ba99",
     "label": "Glass-03",
     "name": "Glass .03"
   },
   {
-    "hex": " #bcb472",
+    "hex": "#bcb472",
     "label": "Leaf-04",
     "name": "Leaf .04"
   },
   {
-    "hex": " #998f5b",
+    "hex": "#998f5b",
     "label": "Leaf-05",
     "name": "Leaf .05"
   },
   {
-    "hex": " #969873",
+    "hex": "#969873",
     "label": "Glass-04",
     "name": "Glass .04"
   },
   {
-    "hex": " #6e7e60",
+    "hex": "#6e7e60",
     "label": "Glass-05",
     "name": "Glass .05"
   },
   {
-    "hex": " #696346",
+    "hex": "#696346",
     "label": "Glass-06",
     "name": "Glass .06"
   },
   {
-    "hex": " #cdd9c2",
+    "hex": "#cdd9c2",
     "label": "Leaf-06",
     "name": "Leaf .06"
   },
   {
-    "hex": " #dbe8a7",
+    "hex": "#dbe8a7",
     "label": "Sprout-05",
     "name": "Sprout .05"
   },
   {
-    "hex": " #dde5a9",
+    "hex": "#dde5a9",
     "label": "Leaf-07",
     "name": "Leaf .07"
   },
   {
-    "hex": " #d8dbac",
+    "hex": "#d8dbac",
     "label": "Thrive-01",
     "name": "Thrive .01"
   },
   {
-    "hex": " #ccce7a",
+    "hex": "#ccce7a",
     "label": "Thrive-02",
     "name": "Thrive .02"
   },
   {
-    "hex": " #c3d263",
+    "hex": "#c3d263",
     "label": "Petal-02",
     "name": "Petal .02"
   },
   {
-    "hex": " #b0c05d",
+    "hex": "#b0c05d",
     "label": "Thrive-03",
     "name": "Thrive .03"
   },
   {
-    "hex": " #a2c8a1",
+    "hex": "#a2c8a1",
     "label": "Thrive-04",
     "name": "Thrive .04"
   },
   {
-    "hex": " #83ae82",
+    "hex": "#83ae82",
     "label": "Thrive-05",
     "name": "Thrive .05"
   },
   {
-    "hex": " #128458",
+    "hex": "#128458",
     "label": "Thrive-06",
     "name": "Thrive .06"
   },
   {
-    "hex": " #cfe9e0",
+    "hex": "#cfe9e0",
     "label": "Water-01",
     "name": "Water .01"
   },
   {
-    "hex": " #bcc8bc",
+    "hex": "#bcc8bc",
     "label": "Water-02",
     "name": "Water .02"
   },
   {
-    "hex": " #bbd0d2",
+    "hex": "#bbd0d2",
     "label": "Water-03",
     "name": "Water .03"
   },
   {
-    "hex": " #9fb4b4",
+    "hex": "#9fb4b4",
     "label": "Water-04",
     "name": "Water .04"
   },
   {
-    "hex": " #82979d",
+    "hex": "#82979d",
     "label": "Water-05",
     "name": "Water .05"
   },
   {
-    "hex": " #c5d7d2",
+    "hex": "#c5d7d2",
     "label": "Wool-01",
     "name": "Wool .01"
   },
   {
-    "hex": " #c1cdcd",
+    "hex": "#c1cdcd",
     "label": "Wool-02",
     "name": "Wool .02"
   },
   {
-    "hex": " #a1abab",
+    "hex": "#a1abab",
     "label": "Wool-03",
     "name": "Wool .03"
   },
   {
-    "hex": " #9eaea3",
+    "hex": "#9eaea3",
     "label": "Water-06",
     "name": "Water .06"
   },
   {
-    "hex": " #a6cdc2",
+    "hex": "#a6cdc2",
     "label": "Water-07",
     "name": "Water .07"
   },
   {
-    "hex": " #ade8e2",
+    "hex": "#ade8e2",
     "label": "Sprout-01",
     "name": "Sprout .01"
   },
   {
-    "hex": " #ccdce7",
+    "hex": "#ccdce7",
     "label": "Sprout-03",
     "name": "Sprout .03"
   },
   {
-    "hex": " #cae9ee",
+    "hex": "#cae9ee",
     "label": "Dream-01",
     "name": "Dream .01"
   },
   {
-    "hex": " #bde1dd",
+    "hex": "#bde1dd",
     "label": "Dream-02",
     "name": "Dream .02"
   },
   {
-    "hex": " #b4cbd9",
+    "hex": "#b4cbd9",
     "label": "Dream-03",
     "name": "Dream .03"
   },
   {
-    "hex": " #9cc7c4",
+    "hex": "#9cc7c4",
     "label": "Dream-04",
     "name": "Dream .04"
   },
   {
-    "hex": " #18887c",
+    "hex": "#18887c",
     "label": "Dream-05",
     "name": "Dream .05"
   },
   {
-    "hex": " #0e707b",
+    "hex": "#0e707b",
     "label": "Dream-06",
     "name": "Dream .06"
   },
   {
-    "hex": " #587675",
+    "hex": "#587675",
     "label": "Wool-05",
     "name": "Wool .05"
   },
   {
-    "hex": " #485761",
+    "hex": "#485761",
     "label": "Wool-06",
     "name": "Wool .06"
   },
   {
-    "hex": " #1f4992",
+    "hex": "#1f4992",
     "label": "Petal-05",
     "name": "Petal .05"
   },
   {
-    "hex": " #fcba7d",
+    "hex": "#fcba7d",
     "label": "Sprout-02",
     "name": "Sprout .02"
   },
   {
-    "hex": " #c49c6d",
+    "hex": "#c49c6d",
     "label": "Clay-01",
     "name": "Clay .01"
   },
   {
-    "hex": " #cf8744",
+    "hex": "#cf8744",
     "label": "Clay-02",
     "name": "Clay .02"
   },
   {
-    "hex": " #a16941",
+    "hex": "#a16941",
     "label": "Clay-03",
     "name": "Clay .03"
   },
   {
-    "hex": " #ff963a",
+    "hex": "#ff963a",
     "label": "Create-02",
     "name": "Create .02"
   },
   {
-    "hex": " #df892a",
+    "hex": "#df892a",
     "label": "Petal-01",
     "name": "Petal .01"
   },
   {
-    "hex": " #c68736",
+    "hex": "#c68736",
     "label": "Wood-01",
     "name": "Wood .01"
   },
   {
-    "hex": " #b2683a",
+    "hex": "#b2683a",
     "label": "Wood-02",
     "name": "Wood .02"
   },
   {
-    "hex": " #c27136",
+    "hex": "#c27136",
     "label": "Create-03",
     "name": "Create .03"
   },
   {
-    "hex": " #8c4d35",
+    "hex": "#8c4d35",
     "label": "Clay-04",
     "name": "Clay .04"
   },
   {
-    "hex": " #752b22",
+    "hex": "#752b22",
     "label": "Clay-05",
     "name": "Clay .05"
   },
   {
-    "hex": " #c27355",
+    "hex": "#c27355",
     "label": "Clay-07",
     "name": "Clay .07"
   },
   {
-    "hex": " #ba4133",
+    "hex": "#ba4133",
     "label": "Petal-06",
     "name": "Petal .06"
   },
   {
-    "hex": " #b8352e",
+    "hex": "#b8352e",
     "label": "Create-04",
     "name": "Create .04"
   },
   {
-    "hex": " #942a35",
+    "hex": "#942a35",
     "label": "Create-05",
     "name": "Create .05"
   },
   {
-    "hex": " #7c2a1c",
+    "hex": "#7c2a1c",
     "label": "Wood-03",
     "name": "Wood .03"
   },
   {
-    "hex": " #67272a",
+    "hex": "#67272a",
     "label": "Wood-04",
     "name": "Wood .04"
   },
   {
-    "hex": " #aa3e71",
+    "hex": "#aa3e71",
     "label": "Petal-04",
     "name": "Petal .04"
   },
   {
-    "hex": " #f1a1a6",
+    "hex": "#f1a1a6",
     "label": "Petal-03",
     "name": "Petal .03"
   },
   {
-    "hex": " #f7dde0",
+    "hex": "#f7dde0",
     "label": "Sprout-06",
     "name": "Sprout .06"
   },
   {
-    "hex": " #e3dbf2",
+    "hex": "#e3dbf2",
     "label": "Sprout-07",
     "name": "Sprout .07"
   },
   {
-    "hex": " #cec4c5",
+    "hex": "#cec4c5",
     "label": "Air-07",
     "name": "Air .07"
   },
   {
-    "hex": " #8b8a8c",
+    "hex": "#8b8a8c",
     "label": "Wool-04",
     "name": "Wool .04"
   },
   {
-    "hex": " #6f595d",
+    "hex": "#6f595d",
     "label": "Wood-05",
     "name": "Wood .05"
   },
   {
-    "hex": " #5e3d5a",
+    "hex": "#5e3d5a",
     "label": "Create-06",
     "name": "Create .06"
   },
   {
-    "hex": " #652f53",
+    "hex": "#652f53",
     "label": "Petal-07",
     "name": "Petal .07"
   },
   {
-    "hex": " #e1d6bb",
+    "hex": "#e1d6bb",
     "label": "Stone-01",
     "name": "Stone .01"
   },
   {
-    "hex": " #c1a878",
+    "hex": "#c1a878",
     "label": "Stone-02",
     "name": "Stone .02"
   },
   {
-    "hex": " #cbc6b1",
+    "hex": "#cbc6b1",
     "label": "Metal-01",
     "name": "Metal .01"
   },
   {
-    "hex": " #bdb091",
+    "hex": "#bdb091",
     "label": "Metal-02",
     "name": "Metal .02"
   },
   {
-    "hex": " #a89d7e",
+    "hex": "#a89d7e",
     "label": "Stone-03",
     "name": "Stone .03"
   },
   {
-    "hex": " #c9cabd",
+    "hex": "#c9cabd",
     "label": "Stone-04",
     "name": "Stone .04"
   },
   {
-    "hex": " #b5b8b1",
+    "hex": "#b5b8b1",
     "label": "Metal-03",
     "name": "Metal .03"
   },
   {
-    "hex": " #9fa198",
+    "hex": "#9fa198",
     "label": "Metal-04",
     "name": "Metal .04"
   },
   {
-    "hex": " #aaa593",
+    "hex": "#aaa593",
     "label": "Stone-05",
     "name": "Stone .05"
   },
   {
-    "hex": " #746d5a",
+    "hex": "#746d5a",
     "label": "Stone-06",
     "name": "Stone .06"
   },
   {
-    "hex": " #848a86",
+    "hex": "#848a86",
     "label": "Stone-07",
     "name": "Stone .07"
   },
   {
-    "hex": " #535654",
+    "hex": "#535654",
     "label": "Metal-05",
     "name": "Metal .05"
   },
   {
-    "hex": " #3f4647",
+    "hex": "#3f4647",
     "label": "Metal-06",
     "name": "Metal .06"
   },
   {
-    "hex": " #d5d3bf",
+    "hex": "#d5d3bf",
     "label": "Nourish-01",
     "name": "Nourish .01"
   },
   {
-    "hex": " #c5c2af",
+    "hex": "#c5c2af",
     "label": "Nourish-02",
     "name": "Nourish .02"
   },
   {
-    "hex": " #a5a392",
+    "hex": "#a5a392",
     "label": "Nourish-03",
     "name": "Nourish .03"
   },
   {
-    "hex": " #a3977f",
+    "hex": "#a3977f",
     "label": "Nourish-04",
     "name": "Nourish .04"
   },
   {
-    "hex": " #675544",
+    "hex": "#675544",
     "label": "Clay-06",
     "name": "Clay .06"
   },
   {
-    "hex": " #53453c",
+    "hex": "#53453c",
     "label": "Nourish-05",
     "name": "Nourish .05"
   },
   {
-    "hex": " #312f24",
+    "hex": "#312f24",
     "label": "Wood-06",
     "name": "Wood .06"
   },
   {
-    "hex": " #313536",
+    "hex": "#313536",
     "label": "Nourish-06",
     "name": "Nourish .06"
   }

--- a/json/farrow-ball.json
+++ b/json/farrow-ball.json
@@ -1,661 +1,661 @@
 [
   {
-    "hex": " #fbf8f4",
+    "hex": "#fbf8f4",
     "label": "2005",
     "name": "All White"
   },
   {
-    "hex": " #eee9e7",
+    "hex": "#eee9e7",
     "label": "273",
     "name": "Wevet"
   },
   {
-    "hex": " #f7f3e8",
+    "hex": "#f7f3e8",
     "label": "239",
     "name": "Wimborne White"
   },
   {
-    "hex": " #f7f1e3",
+    "hex": "#f7f1e3",
     "label": "2003",
     "name": "Pointing"
   },
   {
-    "hex": " #ede9d8",
+    "hex": "#ede9d8",
     "label": "2010",
     "name": "James White"
   },
   {
-    "hex": " #cec1ad",
+    "hex": "#cec1ad",
     "label": "211",
     "name": "Stony Ground"
   },
   {
-    "hex": " #f5ecd9",
+    "hex": "#f5ecd9",
     "label": "2002",
     "name": "White Tie"
   },
   {
-    "hex": " #f5e8d0",
+    "hex": "#f5e8d0",
     "label": "59",
     "name": "New White"
   },
   {
-    "hex": " #e4d5bc",
+    "hex": "#e4d5bc",
     "label": "2013",
     "name": "Matchstick"
   },
   {
-    "hex": " #ddcdae",
+    "hex": "#ddcdae",
     "label": "8",
     "name": "String"
   },
   {
-    "hex": " #d8c4a8",
+    "hex": "#d8c4a8",
     "label": "213",
     "name": "Savage Ground"
   },
   {
-    "hex": " #d6c39e",
+    "hex": "#d6c39e",
     "label": "16",
     "name": "Cord"
   },
   {
-    "hex": " #e8e0d1",
+    "hex": "#e8e0d1",
     "label": "2004",
     "name": "Slipper Satin"
   },
   {
-    "hex": " #e8dec9",
+    "hex": "#e8dec9",
     "label": "1",
     "name": "Lime White"
   },
   {
-    "hex": " #e0d5be",
+    "hex": "#e0d5be",
     "label": "3",
     "name": "Off-White"
   },
   {
-    "hex": " #cfc3ad",
+    "hex": "#cfc3ad",
     "label": "4",
     "name": "Old White"
   },
   {
-    "hex": " #b4a693",
+    "hex": "#b4a693",
     "label": "17",
     "name": "Light Gray"
   },
   {
-    "hex": " #998976",
+    "hex": "#998976",
     "label": "40",
     "name": "Mouse's Back"
   },
   {
-    "hex": " #e6dfd1",
+    "hex": "#e6dfd1",
     "label": "291",
     "name": "School House White"
   },
   {
-    "hex": " #ded8c6",
+    "hex": "#ded8c6",
     "label": "282",
     "name": "Shadow White"
   },
   {
-    "hex": " #d9d2c1",
+    "hex": "#d9d2c1",
     "label": "201",
     "name": "Shaded White"
   },
   {
-    "hex": " #c9beab",
+    "hex": "#c9beab",
     "label": "283",
     "name": "Drop Cloth"
   },
   {
-    "hex": " #cec3ad",
+    "hex": "#cec3ad",
     "label": "15",
     "name": "Bone"
   },
   {
-    "hex": " #b5afa0",
+    "hex": "#b5afa0",
     "label": "5",
     "name": "Hardwick White"
   },
   {
-    "hex": " #eee3d3",
+    "hex": "#eee3d3",
     "label": "2008",
     "name": "Dimity"
   },
   {
-    "hex": " #decfb9",
+    "hex": "#decfb9",
     "label": "226",
     "name": "Joa's White"
   },
   {
-    "hex": " #d6c2ac",
+    "hex": "#d6c2ac",
     "label": "264",
     "name": "Oxford Stone"
   },
   {
-    "hex": " #b6a38f",
+    "hex": "#b6a38f",
     "label": "6",
     "name": "London Stone"
   },
   {
-    "hex": " #b49d8d",
+    "hex": "#b49d8d",
     "label": "28",
     "name": "Dead Salmon"
   },
   {
-    "hex": " #726454",
+    "hex": "#726454",
     "label": "290",
     "name": "Salon Drab"
   },
   {
-    "hex": " #e5e0db",
+    "hex": "#e5e0db",
     "label": "2001",
     "name": "Strong White"
   },
   {
-    "hex": " #ddd8cf",
+    "hex": "#ddd8cf",
     "label": "274",
     "name": "Ammonite"
   },
   {
-    "hex": " #d1cbc3",
+    "hex": "#d1cbc3",
     "label": "228",
     "name": "Cornforth White"
   },
   {
-    "hex": " #c4beb4",
+    "hex": "#c4beb4",
     "label": "275",
     "name": "Purbeck Stone"
   },
   {
-    "hex": " #D3CFCD",
+    "hex": "#D3CFCD",
     "label": "284",
     "name": "Worsted"
   },
   {
-    "hex": " #8b857f",
+    "hex": "#8b857f",
     "label": "276",
     "name": "Mole's Breath"
   },
   {
-    "hex": " #cfcec0",
+    "hex": "#cfcec0",
     "label": "285",
     "name": "Cromarty"
   },
   {
-    "hex": " #c0c2b3",
+    "hex": "#c0c2b3",
     "label": "266",
     "name": "Mizzle"
   },
   {
-    "hex": " #b4b4a3",
+    "hex": "#b4b4a3",
     "label": "91",
     "name": "Blue Gray"
   },
   {
-    "hex": " #a1a093",
+    "hex": "#a1a093",
     "label": "25",
     "name": "Pigeon"
   },
   {
-    "hex": " #b5b19a",
+    "hex": "#b5b19a",
     "label": "18",
     "name": "French Gray"
   },
   {
-    "hex": " #8b8a77",
+    "hex": "#8b8a77",
     "label": "292",
     "name": "Treron"
   },
   {
-    "hex": " #dddbd9",
+    "hex": "#dddbd9",
     "label": "2011",
     "name": "Blackened"
   },
   {
-    "hex": " #d9d8d3",
+    "hex": "#d9d8d3",
     "label": "277",
     "name": "Dimpse"
   },
   {
-    "hex": " #c8c3bc",
+    "hex": "#c8c3bc",
     "label": "242",
     "name": "Pavilion Gray"
   },
   {
-    "hex": " #b2b1a9",
+    "hex": "#b2b1a9",
     "label": "88",
     "name": "Lamp Room Gray"
   },
   {
-    "hex": " #a2a29d",
+    "hex": "#a2a29d",
     "label": "265",
     "name": "Manor House Gray"
   },
   {
-    "hex": " #8d8d8b",
+    "hex": "#8d8d8b",
     "label": "272",
     "name": "Plummett"
   },
   {
-    "hex": " #dfd6cb",
+    "hex": "#dfd6cb",
     "label": "241",
     "name": "Skimming Stone"
   },
   {
-    "hex": " #ccbfb3",
+    "hex": "#ccbfb3",
     "label": "229",
     "name": "Elephant's Breath"
   },
   {
-    "hex": " #bbb1ab",
+    "hex": "#bbb1ab",
     "label": "267",
     "name": "Dove Tale"
   },
   {
-    "hex": " #9f9389",
+    "hex": "#9f9389",
     "label": "243",
     "name": "Charleston Gray"
   },
   {
-    "hex": " #786963",
+    "hex": "#786963",
     "label": "244",
     "name": "London Clay"
   },
   {
-    "hex": " #5d3b42",
+    "hex": "#5d3b42",
     "label": "222",
     "name": "Brinjal"
   },
   {
-    "hex": " #c4b2a2",
+    "hex": "#c4b2a2",
     "label": "293",
     "name": "Jitney"
   },
   {
-    "hex": " #d6c8c3",
+    "hex": "#d6c8c3",
     "label": "286",
     "name": "Peignoir"
   },
   {
-    "hex": " #ccc8ce",
+    "hex": "#ccc8ce",
     "label": "270",
     "name": "Calluna"
   },
   {
-    "hex": " #8d8089",
+    "hex": "#8d8089",
     "label": "271",
     "name": "Brassica"
   },
   {
-    "hex": " #50414c",
+    "hex": "#50414c",
     "label": "254",
     "name": "Pelt"
   },
   {
-    "hex": " #494248",
+    "hex": "#494248",
     "label": "294",
     "name": "Paean Black"
   },
   {
-    "hex": " #fde7e5",
+    "hex": "#fde7e5",
     "label": "245",
     "name": "Middleton Pink"
   },
   {
-    "hex": " #e6d1cb",
+    "hex": "#e6d1cb",
     "label": "230",
     "name": "Calamine"
   },
   {
-    "hex": " #ecb7b8",
+    "hex": "#ecb7b8",
     "label": "278",
     "name": "Nancy's Blushes"
   },
   {
-    "hex": " #c57b67",
+    "hex": "#c57b67",
     "label": "64",
     "name": "Red Earth"
   },
   {
-    "hex": " #a15a4d",
+    "hex": "#a15a4d",
     "label": "42",
     "name": "Picture Gallery Red"
   },
   {
-    "hex": " #a04344",
+    "hex": "#a04344",
     "label": "248",
     "name": "Incarnadine"
   },
   {
-    "hex": " #e7dedb",
+    "hex": "#e7dedb",
     "label": "2006",
     "name": "Great White"
   },
   {
-    "hex": " #A0837F",
+    "hex": "#A0837F",
     "label": "295",
     "name": "Sulking Room Pink"
   },
   {
-    "hex": " #c7a4a6",
+    "hex": "#c7a4a6",
     "label": "246",
     "name": "Cinder Rose"
   },
   {
-    "hex": " #bf7a8f",
+    "hex": "#bf7a8f",
     "label": "296",
     "name": "Rangwali"
   },
   {
-    "hex": " #efd6c7",
+    "hex": "#efd6c7",
     "label": "202",
     "name": "Pink Ground"
   },
   {
-    "hex": " #dfc2af",
+    "hex": "#dfc2af",
     "label": "231",
     "name": "Setting Plaster"
   },
   {
-    "hex": " #a53c49",
+    "hex": "#a53c49",
     "label": "217",
     "name": "Rectory Red"
   },
   {
-    "hex": " #8f4e4d",
+    "hex": "#8f4e4d",
     "label": "43",
     "name": "Eating Room Red"
   },
   {
-    "hex": " #994a50",
+    "hex": "#994a50",
     "label": "96",
     "name": "Radicchio"
   },
   {
-    "hex": " #6d4247",
+    "hex": "#6d4247",
     "label": "297",
     "name": "Preference Red"
   },
   {
-    "hex": " #d65f3d",
+    "hex": "#d65f3d",
     "label": "268",
     "name": "Charlotte's Locks"
   },
   {
-    "hex": " #b64f48",
+    "hex": "#b64f48",
     "label": "212",
     "name": "Blazer"
   },
   {
-    "hex": " #f1e6c8",
+    "hex": "#f1e6c8",
     "label": "2012",
     "name": "House White"
   },
   {
-    "hex": " #eadfb7",
+    "hex": "#eadfb7",
     "label": "71",
     "name": "Pale Hound"
   },
   {
-    "hex": " #f7e29d",
+    "hex": "#f7e29d",
     "label": "233",
     "name": "Dayroom Yellow"
   },
   {
-    "hex": " #f5d27b",
+    "hex": "#f5d27b",
     "label": "74",
     "name": "Citron"
   },
   {
-    "hex": " #f2cf86",
+    "hex": "#f2cf86",
     "label": "218",
     "name": "Yellow Ground"
   },
   {
-    "hex": " #ecc363",
+    "hex": "#ecc363",
     "label": "223",
     "name": "Babouche"
   },
   {
-    "hex": " #fdedd7",
+    "hex": "#fdedd7",
     "label": "203",
     "name": "Tallow"
   },
   {
-    "hex": " #efdbb3",
+    "hex": "#efdbb3",
     "label": "67",
     "name": "Farrow's Cream"
   },
   {
-    "hex": " #efd5a1",
+    "hex": "#efd5a1",
     "label": "68",
     "name": "Dorset Cream"
   },
   {
-    "hex": " #dfc795",
+    "hex": "#dfc795",
     "label": "37",
     "name": "Hay"
   },
   {
-    "hex": " #dcb771",
+    "hex": "#dcb771",
     "label": "51",
     "name": "Sudbury Yellow"
   },
   {
-    "hex": " #cb9e59",
+    "hex": "#cb9e59",
     "label": "66",
     "name": "India Yellow"
   },
   {
-    "hex": " #dbdab6",
+    "hex": "#dbdab6",
     "label": "206",
     "name": "Green Ground"
   },
   {
-    "hex": " #c4c6a5",
+    "hex": "#c4c6a5",
     "label": "32",
     "name": "Cooking Apple Green"
   },
   {
-    "hex": " #bcb596",
+    "hex": "#bcb596",
     "label": "75",
     "name": "Ball Green"
   },
   {
-    "hex": " #899081",
+    "hex": "#899081",
     "label": "79",
     "name": "Card Room Green"
   },
   {
-    "hex": " #737c70",
+    "hex": "#737c70",
     "label": "47",
     "name": "Green Smoke"
   },
   {
-    "hex": " #464c49",
+    "hex": "#464c49",
     "label": "93",
     "name": "Studio Green"
   },
   {
-    "hex": " #c8bd83",
+    "hex": "#c8bd83",
     "label": "251",
     "name": "Churlish Green"
   },
   {
-    "hex": " #919f70",
+    "hex": "#919f70",
     "label": "287",
     "name": "Yeabridge Green"
   },
   {
-    "hex": " #94a68a",
+    "hex": "#94a68a",
     "label": "81",
     "name": "Breakfast Room Green"
   },
   {
-    "hex": " #768769",
+    "hex": "#768769",
     "label": "34",
     "name": "Calke Green"
   },
   {
-    "hex": " #686a47",
+    "hex": "#686a47",
     "label": "298",
     "name": "Bancha"
   },
   {
-    "hex": " #84b59c",
+    "hex": "#84b59c",
     "label": "214",
     "name": "Arsenic"
   },
   {
-    "hex": " #babba5",
+    "hex": "#babba5",
     "label": "234",
     "name": "Vert de Terre"
   },
   {
-    "hex": " #a1a189",
+    "hex": "#a1a189",
     "label": "19",
     "name": "Lichen"
   },
   {
-    "hex": " #8b9d9b",
+    "hex": "#8b9d9b",
     "label": "85",
     "name": "Oval Room Blue"
   },
   {
-    "hex": " #7997a1",
+    "hex": "#7997a1",
     "label": "86",
     "name": "Stone Blue"
   },
   {
-    "hex": " #6A7C80",
+    "hex": "#6A7C80",
     "label": "299",
     "name": "De Nimes"
   },
   {
-    "hex": " #586768",
+    "hex": "#586768",
     "label": "289",
     "name": "Inchyra Blue"
   },
   {
-    "hex": " #e5e7dc",
+    "hex": "#e5e7dc",
     "label": "252",
     "name": "Pavilion Blue"
   },
   {
-    "hex": " #d9dcd2",
+    "hex": "#d9dcd2",
     "label": "204",
     "name": "Pale Powder"
   },
   {
-    "hex": " #c0cdc2",
+    "hex": "#c0cdc2",
     "label": "236",
     "name": "Teresa's Green"
   },
   {
-    "hex": " #adbdb2",
+    "hex": "#adbdb2",
     "label": "84",
     "name": "Green Blue"
   },
   {
-    "hex": " #99b0ab",
+    "hex": "#99b0ab",
     "label": "82",
     "name": "Dix Blue"
   },
   {
-    "hex": " #427e83",
+    "hex": "#427e83",
     "label": "288",
     "name": "Vardo"
   },
   {
-    "hex": " #d5dbdb",
+    "hex": "#d5dbdb",
     "label": "235",
     "name": "Borrowed Light"
   },
   {
-    "hex": " #ccd0cd",
+    "hex": "#ccd0cd",
     "label": "205",
     "name": "Skylight"
   },
   {
-    "hex": " #b8bcb5",
+    "hex": "#b8bcb5",
     "label": "22",
     "name": "Light Blue"
   },
   {
-    "hex": " #b2bfc5",
+    "hex": "#b2bfc5",
     "label": "27",
     "name": "Parma Gray"
   },
   {
-    "hex": " #a1b8ca",
+    "hex": "#a1b8ca",
     "label": "89",
     "name": "Lulworth Blue"
   },
   {
-    "hex": " #6a90b4",
+    "hex": "#6a90b4",
     "label": "237",
     "name": "Cook's Blue"
   },
   {
-    "hex": " #e8eeea",
+    "hex": "#e8eeea",
     "label": "269",
     "name": "Cabbage White"
   },
   {
-    "hex": " #a1c5c8",
+    "hex": "#a1c5c8",
     "label": "210",
     "name": "Blue Ground"
   },
   {
-    "hex": " #599ec4",
+    "hex": "#599ec4",
     "label": "280",
     "name": "St Giles Blue"
   },
   {
-    "hex": " #636e8f",
+    "hex": "#636e8f",
     "label": "220",
     "name": "Pitch Blue"
   },
   {
-    "hex": " #4d5b6a",
+    "hex": "#4d5b6a",
     "label": "281",
     "name": "Stiffkey Blue"
   },
   {
-    "hex": " #3d4e57",
+    "hex": "#3d4e57",
     "label": "30",
     "name": "Hague Blue"
   },
   {
-    "hex": " #534644",
+    "hex": "#534644",
     "label": "36",
     "name": "Mahogany"
   },
   {
-    "hex": " #4d4746",
+    "hex": "#4d4746",
     "label": "255",
     "name": "Tanner's Brown"
   },
   {
-    "hex": " #626664",
+    "hex": "#626664",
     "label": "26",
     "name": "Down Pipe"
   },
   {
-    "hex": " #45484b",
+    "hex": "#45484b",
     "label": "31",
     "name": "Railings"
   },
   {
-    "hex": " #444546",
+    "hex": "#444546",
     "label": "57",
     "name": "Off-Black"
   },
   {
-    "hex": " #3b3938",
+    "hex": "#3b3938",
     "label": "256",
     "name": "Pitch Black"
   }

--- a/json/vista.json
+++ b/json/vista.json
@@ -7325,6602 +7325,6602 @@
     "name": "Vermont Slate"
   },
   {
-    "hex": "#683c68 ",
+    "hex": "#683c68",
     "label": "K-0",
     "name": "Iris Impact"
   },
   {
-    "hex": "#b376b3 ",
+    "hex": "#b376b3",
     "label": "K-1",
     "name": "Happy Hyacinth"
   },
   {
-    "hex": "#c593c8 ",
+    "hex": "#c593c8",
     "label": "K-2",
     "name": "Japanese Lilac"
   },
   {
-    "hex": "#d2a8d4 ",
+    "hex": "#d2a8d4",
     "label": "K-3",
     "name": "Very Violet"
   },
   {
-    "hex": "#e8c0e3 ",
+    "hex": "#e8c0e3",
     "label": "K-4",
     "name": "Micaela Abril"
   },
   {
-    "hex": "#eed1e9 ",
+    "hex": "#eed1e9",
     "label": "K-5",
     "name": "Lilac Lady"
   },
   {
-    "hex": "#f2e1ec ",
+    "hex": "#f2e1ec",
     "label": "K-6",
     "name": "Purple Peace"
   },
   {
-    "hex": "#f3eeee ",
+    "hex": "#f3eeee",
     "label": "K-7",
     "name": "Light Lavender"
   },
   {
-    "hex": "#483d4c ",
+    "hex": "#483d4c",
     "label": "K-8",
     "name": "Midnight Affair"
   },
   {
-    "hex": "#75677f ",
+    "hex": "#75677f",
     "label": "K-9",
     "name": "Jubilation"
   },
   {
-    "hex": "#8a7c93 ",
+    "hex": "#8a7c93",
     "label": "K-10",
     "name": "Pandora's Purple"
   },
   {
-    "hex": "#b0a4b9 ",
+    "hex": "#b0a4b9",
     "label": "K-11",
     "name": "Italian Iris"
   },
   {
-    "hex": "#c9b8cb ",
+    "hex": "#c9b8cb",
     "label": "K-12",
     "name": "Wisteria Wish"
   },
   {
-    "hex": "#d5c7d6 ",
+    "hex": "#d5c7d6",
     "label": "K-13",
     "name": "Last of the Lilacs"
   },
   {
-    "hex": "#e3d9e1 ",
+    "hex": "#e3d9e1",
     "label": "K-14",
     "name": "Lavender Laugh"
   },
   {
-    "hex": "#efeaeb ",
+    "hex": "#efeaeb",
     "label": "K-15",
     "name": "Lilac Frost"
   },
   {
-    "hex": "#583f64 ",
+    "hex": "#583f64",
     "label": "K-16",
     "name": "Royal Rajah"
   },
   {
-    "hex": "#8c75a2 ",
+    "hex": "#8c75a2",
     "label": "K-17",
     "name": "Regal Jewel"
   },
   {
-    "hex": "#a693bc ",
+    "hex": "#a693bc",
     "label": "K-18",
     "name": "Lilac Garden"
   },
   {
-    "hex": "#c2b0d1 ",
+    "hex": "#c2b0d1",
     "label": "K-19",
     "name": "Teresa's True Color"
   },
   {
-    "hex": "#d3c1dd ",
+    "hex": "#d3c1dd",
     "label": "K-20",
     "name": "Lavender Lilac"
   },
   {
-    "hex": "#e4d9e8 ",
+    "hex": "#e4d9e8",
     "label": "K-21",
     "name": "Spring Crocus"
   },
   {
-    "hex": "#ebe3eb ",
+    "hex": "#ebe3eb",
     "label": "K-22",
     "name": "Pale Pansy"
   },
   {
-    "hex": "#efe9ec ",
+    "hex": "#efe9ec",
     "label": "K-23",
     "name": "Lilac Lass"
   },
   {
-    "hex": "#583e7b ",
+    "hex": "#583e7b",
     "label": "K-24",
     "name": "Iris Illusion"
   },
   {
-    "hex": "#8771b2 ",
+    "hex": "#8771b2",
     "label": "K-25",
     "name": "Royal Raul"
   },
   {
-    "hex": "#a998cd ",
+    "hex": "#a998cd",
     "label": "K-26",
     "name": "Lavender Legend"
   },
   {
-    "hex": "#baaad8 ",
+    "hex": "#baaad8",
     "label": "K-27",
     "name": "Purple Possibility"
   },
   {
-    "hex": "#d0c0e5 ",
+    "hex": "#d0c0e5",
     "label": "K-28",
     "name": "Pansy Potpourri"
   },
   {
-    "hex": "#ddd1eb ",
+    "hex": "#ddd1eb",
     "label": "K-29",
     "name": "Violetville"
   },
   {
-    "hex": "#e6deee ",
+    "hex": "#e6deee",
     "label": "K-30",
     "name": "Fancy Pansy"
   },
   {
-    "hex": "#ece7ee ",
+    "hex": "#ece7ee",
     "label": "K-31",
     "name": "Lavender Splash"
   },
   {
-    "hex": "#4d406b ",
+    "hex": "#4d406b",
     "label": "K-32",
     "name": "Dark Triumph"
   },
   {
-    "hex": "#8173ab ",
+    "hex": "#8173ab",
     "label": "K-33",
     "name": "Blooming Lilac"
   },
   {
-    "hex": "#a198c6 ",
+    "hex": "#a198c6",
     "label": "K-34",
     "name": "Hermosa"
   },
   {
-    "hex": "#a79fca ",
+    "hex": "#a79fca",
     "label": "K-35",
     "name": "Gateway to Paradise"
   },
   {
-    "hex": "#bbb3d1 ",
+    "hex": "#bbb3d1",
     "label": "K-36",
     "name": "Lilac Lake"
   },
   {
-    "hex": "#cdc3dc ",
+    "hex": "#cdc3dc",
     "label": "K-37",
     "name": "Evocative Antonia"
   },
   {
-    "hex": "#dbd3e5 ",
+    "hex": "#dbd3e5",
     "label": "K-38",
     "name": "Carefree Breeze"
   },
   {
-    "hex": "#ede9ef ",
+    "hex": "#ede9ef",
     "label": "K-39",
     "name": "Greek Goddess"
   },
   {
-    "hex": "#46404d ",
+    "hex": "#46404d",
     "label": "K-40",
     "name": "Queen Victoria"
   },
   {
-    "hex": "#6b6678 ",
+    "hex": "#6b6678",
     "label": "K-41",
     "name": "Purple Pansies"
   },
   {
-    "hex": "#8d899c ",
+    "hex": "#8d899c",
     "label": "K-42",
     "name": "Garden Beauty"
   },
   {
-    "hex": "#aba7b7 ",
+    "hex": "#aba7b7",
     "label": "K-43",
     "name": "Lap of Luxury"
   },
   {
-    "hex": "#c2b9c7 ",
+    "hex": "#c2b9c7",
     "label": "K-44",
     "name": "Hyacinth Haze"
   },
   {
-    "hex": "#d0cad4 ",
+    "hex": "#d0cad4",
     "label": "K-45",
     "name": "Shy Violet"
   },
   {
-    "hex": "#ddd8de ",
+    "hex": "#ddd8de",
     "label": "K-46",
     "name": "Easter Party"
   },
   {
-    "hex": "#eae7e8 ",
+    "hex": "#eae7e8",
     "label": "K-47",
     "name": "Lilac Breeze"
   },
   {
-    "hex": "#443e50 ",
+    "hex": "#443e50",
     "label": "K-48",
     "name": "Royal Treatment"
   },
   {
-    "hex": "#6b6681 ",
+    "hex": "#6b6681",
     "label": "K-49",
     "name": "Vintage Velvet"
   },
   {
-    "hex": "#7c7791 ",
+    "hex": "#7c7791",
     "label": "K-50",
     "name": "Suzette"
   },
   {
-    "hex": "#9a96b0 ",
+    "hex": "#9a96b0",
     "label": "K-51",
     "name": "Barrymore"
   },
   {
-    "hex": "#a7a4bb ",
+    "hex": "#a7a4bb",
     "label": "K-52",
     "name": "Luster Blue"
   },
   {
-    "hex": "#c2bbcf ",
+    "hex": "#c2bbcf",
     "label": "K-53",
     "name": "Province"
   },
   {
-    "hex": "#d5d0dd ",
+    "hex": "#d5d0dd",
     "label": "K-54",
     "name": "Frosty Glaze"
   },
   {
-    "hex": "#e3dee5 ",
+    "hex": "#e3dee5",
     "label": "K-55",
     "name": "Fancy That"
   },
   {
-    "hex": "#4b4169 ",
+    "hex": "#4b4169",
     "label": "K-56",
     "name": "Rare Orchid"
   },
   {
-    "hex": "#75709e ",
+    "hex": "#75709e",
     "label": "K-57",
     "name": "Plum Berry"
   },
   {
-    "hex": "#8481ae ",
+    "hex": "#8481ae",
     "label": "K-58",
     "name": "Grape Gathering"
   },
   {
-    "hex": "#9794be ",
+    "hex": "#9794be",
     "label": "K-59",
     "name": "Royal Glimmer"
   },
   {
-    "hex": "#a5a1c9 ",
+    "hex": "#a5a1c9",
     "label": "K-60",
     "name": "Lined with Lilacs"
   },
   {
-    "hex": "#ccc8e2 ",
+    "hex": "#ccc8e2",
     "label": "K-61",
     "name": "Pick of the Patch"
   },
   {
-    "hex": "#dad7e7 ",
+    "hex": "#dad7e7",
     "label": "K-62",
     "name": "Pastel Princess"
   },
   {
-    "hex": "#e4e2ea ",
+    "hex": "#e4e2ea",
     "label": "K-63",
     "name": "Tentative Dawn"
   },
   {
-    "hex": "#50498a ",
+    "hex": "#50498a",
     "label": "K-64",
     "name": "Petulant Pat"
   },
   {
-    "hex": "#6d6db1 ",
+    "hex": "#6d6db1",
     "label": "K-65",
     "name": "Exotic Beauty"
   },
   {
-    "hex": "#9092cb ",
+    "hex": "#9092cb",
     "label": "K-66",
     "name": "Adora"
   },
   {
-    "hex": "#aaabda ",
+    "hex": "#aaabda",
     "label": "K-67",
     "name": "Petal Soft"
   },
   {
-    "hex": "#c0c0e6 ",
+    "hex": "#c0c0e6",
     "label": "K-68",
     "name": "Peak of Perfection"
   },
   {
-    "hex": "#cccdea ",
+    "hex": "#cccdea",
     "label": "K-69",
     "name": "Flora Vista"
   },
   {
-    "hex": "#dbdced ",
+    "hex": "#dbdced",
     "label": "K-70",
     "name": "Little Cutie"
   },
   {
-    "hex": "#e5e5ee ",
+    "hex": "#e5e5ee",
     "label": "K-71",
     "name": "Natural Beauty"
   },
   {
-    "hex": "#3e3a74 ",
+    "hex": "#3e3a74",
     "label": "K-72",
     "name": "Georgian Court"
   },
   {
-    "hex": "#6a74b7 ",
+    "hex": "#6a74b7",
     "label": "K-73",
     "name": "Purple Wave"
   },
   {
-    "hex": "#8692cc ",
+    "hex": "#8692cc",
     "label": "K-74",
     "name": "Florette"
   },
   {
-    "hex": "#a2a9d9 ",
+    "hex": "#a2a9d9",
     "label": "K-75",
     "name": "Roswell"
   },
   {
-    "hex": "#bbc0e6 ",
+    "hex": "#bbc0e6",
     "label": "K-76",
     "name": "Berry Blush"
   },
   {
-    "hex": "#d0d4ea ",
+    "hex": "#d0d4ea",
     "label": "K-77",
     "name": "Beautiful Berry"
   },
   {
-    "hex": "#e4e6ee ",
+    "hex": "#e4e6ee",
     "label": "K-78",
     "name": "Edge of Dawn"
   },
   {
-    "hex": "#f1f1ef ",
+    "hex": "#f1f1ef",
     "label": "K-79",
     "name": "Alicia"
   },
   {
-    "hex": "#3b465a ",
+    "hex": "#3b465a",
     "label": "K-80",
     "name": "Grand Grape"
   },
   {
-    "hex": "#646b8f ",
+    "hex": "#646b8f",
     "label": "K-81",
     "name": "Mountain Vale"
   },
   {
-    "hex": "#747c9f ",
+    "hex": "#747c9f",
     "label": "K-82",
     "name": "Premiere Purple"
   },
   {
-    "hex": "#8991b2 ",
+    "hex": "#8991b2",
     "label": "K-83",
     "name": "King's Court"
   },
   {
-    "hex": "#a1a6c4 ",
+    "hex": "#a1a6c4",
     "label": "K-84",
     "name": "Purple Paradise"
   },
   {
-    "hex": "#babed7 ",
+    "hex": "#babed7",
     "label": "K-85",
     "name": "Violet Vista"
   },
   {
-    "hex": "#d4d6e4 ",
+    "hex": "#d4d6e4",
     "label": "K-86",
     "name": "Little Grapette"
   },
   {
-    "hex": "#e8e9ec ",
+    "hex": "#e8e9ec",
     "label": "K-87",
     "name": "Loyalist"
   },
   {
-    "hex": "#3d3f4c ",
+    "hex": "#3d3f4c",
     "label": "K-88",
     "name": "Pantry Plum"
   },
   {
-    "hex": "#5c6379 ",
+    "hex": "#5c6379",
     "label": "K-89",
     "name": "Flirty Fran"
   },
   {
-    "hex": "#7e889f ",
+    "hex": "#7e889f",
     "label": "K-90",
     "name": "Pale Orchid"
   },
   {
-    "hex": "#9ea6b9 ",
+    "hex": "#9ea6b9",
     "label": "K-91",
     "name": "Purpley Puff"
   },
   {
-    "hex": "#b2b9ca ",
+    "hex": "#b2b9ca",
     "label": "K-92",
     "name": "Favorite Things"
   },
   {
-    "hex": "#c5cad6 ",
+    "hex": "#c5cad6",
     "label": "K-93",
     "name": "Kecia"
   },
   {
-    "hex": "#d8dce3 ",
+    "hex": "#d8dce3",
     "label": "K-94",
     "name": "Romance in Bloom"
   },
   {
-    "hex": "#e4e6e9 ",
+    "hex": "#e4e6e9",
     "label": "K-95",
     "name": "Flower Girl"
   },
   {
-    "hex": "#343c79 ",
+    "hex": "#343c79",
     "label": "K-96",
     "name": "Evening Magic"
   },
   {
-    "hex": "#506fb3 ",
+    "hex": "#506fb3",
     "label": "K-97",
     "name": "Blue Bounty"
   },
   {
-    "hex": "#7694ce ",
+    "hex": "#7694ce",
     "label": "K-98",
     "name": "Royal Regatta"
   },
   {
-    "hex": "#98afdc ",
+    "hex": "#98afdc",
     "label": "K-99",
     "name": "Prince Charming"
   },
   {
-    "hex": "#acc1e6 ",
+    "hex": "#acc1e6",
     "label": "K-100",
     "name": "Morning Sky"
   },
   {
-    "hex": "#c8d7ed ",
+    "hex": "#c8d7ed",
     "label": "K-101",
     "name": "Breezy Blue"
   },
   {
-    "hex": "#dde5ef ",
+    "hex": "#dde5ef",
     "label": "K-102",
     "name": "Moondancing"
   },
   {
-    "hex": "#edefef ",
+    "hex": "#edefef",
     "label": "K-103",
     "name": "Icy Blue"
   },
   {
-    "hex": "#254280 ",
+    "hex": "#254280",
     "label": "K-104",
     "name": "Evening in Paris"
   },
   {
-    "hex": "#5b79aa ",
+    "hex": "#5b79aa",
     "label": "K-105",
     "name": "Harbor Blue"
   },
   {
-    "hex": "#7d98c4 ",
+    "hex": "#7d98c4",
     "label": "K-106",
     "name": "South Port"
   },
   {
-    "hex": "#98afd3 ",
+    "hex": "#98afd3",
     "label": "K-107",
     "name": "Washed Indigo"
   },
   {
-    "hex": "#a7bdde ",
+    "hex": "#a7bdde",
     "label": "K-108",
     "name": "Scuba Blue"
   },
   {
-    "hex": "#b4c7e2 ",
+    "hex": "#b4c7e2",
     "label": "K-109",
     "name": "By the Bay"
   },
   {
-    "hex": "#cad6e8 ",
+    "hex": "#cad6e8",
     "label": "K-110",
     "name": "Blue Dawn"
   },
   {
-    "hex": "#e3e7ea ",
+    "hex": "#e3e7ea",
     "label": "K-111",
     "name": "Blue Brush Stroke"
   },
   {
-    "hex": "#30405a ",
+    "hex": "#30405a",
     "label": "K-112",
     "name": "Night on the Town"
   },
   {
-    "hex": "#476a8f ",
+    "hex": "#476a8f",
     "label": "K-113",
     "name": "Blue Monday"
   },
   {
-    "hex": "#6e91b3 ",
+    "hex": "#6e91b3",
     "label": "K-114",
     "name": "Postcard Perfect"
   },
   {
-    "hex": "#86a4c2 ",
+    "hex": "#86a4c2",
     "label": "K-115",
     "name": "Far Horizons"
   },
   {
-    "hex": "#a4bfd9 ",
+    "hex": "#a4bfd9",
     "label": "K-116",
     "name": "Blissful Blue"
   },
   {
-    "hex": "#b9cfe1 ",
+    "hex": "#b9cfe1",
     "label": "K-117",
     "name": "Sail Away"
   },
   {
-    "hex": "#cbdbe7 ",
+    "hex": "#cbdbe7",
     "label": "K-118",
     "name": "Summer Sky"
   },
   {
-    "hex": "#e5eced ",
+    "hex": "#e5eced",
     "label": "K-119",
     "name": "Jet Stream"
   },
   {
-    "hex": "#34435b ",
+    "hex": "#34435b",
     "label": "K-120",
     "name": "Blue Moon Bay"
   },
   {
-    "hex": "#4c6b8b ",
+    "hex": "#4c6b8b",
     "label": "K-121",
     "name": "Pleasant Lake"
   },
   {
-    "hex": "#587797 ",
+    "hex": "#587797",
     "label": "K-122",
     "name": "Sea of Marma"
   },
   {
-    "hex": "#6b8aa9 ",
+    "hex": "#6b8aa9",
     "label": "K-123",
     "name": "Piece of the Sky"
   },
   {
-    "hex": "#91acc4 ",
+    "hex": "#91acc4",
     "label": "K-124",
     "name": "Beecher Falls"
   },
   {
-    "hex": "#aec6da ",
+    "hex": "#aec6da",
     "label": "K-125",
     "name": "Quiet Refuge"
   },
   {
-    "hex": "#cbdae5 ",
+    "hex": "#cbdae5",
     "label": "K-126",
     "name": "Precious Dew Drop"
   },
   {
-    "hex": "#e1e8ea ",
+    "hex": "#e1e8ea",
     "label": "K-127",
     "name": "June Breeze"
   },
   {
-    "hex": "#224b8f ",
+    "hex": "#224b8f",
     "label": "K-128",
     "name": "Cascade Twilight"
   },
   {
-    "hex": "#297bc1 ",
+    "hex": "#297bc1",
     "label": "K-129",
     "name": "Soothing Sapphire"
   },
   {
-    "hex": "#569ad7 ",
+    "hex": "#569ad7",
     "label": "K-130",
     "name": "Breathtaking Blue"
   },
   {
-    "hex": "#6ca8de ",
+    "hex": "#6ca8de",
     "label": "K-131",
     "name": "City of Atlantis"
   },
   {
-    "hex": "#8ec1e9 ",
+    "hex": "#8ec1e9",
     "label": "K-132",
     "name": "Blue Sky"
   },
   {
-    "hex": "#abd1ee ",
+    "hex": "#abd1ee",
     "label": "K-133",
     "name": "Young Boy Blue"
   },
   {
-    "hex": "#c8e0ef ",
+    "hex": "#c8e0ef",
     "label": "K-134",
     "name": "Prairie Day"
   },
   {
-    "hex": "#e4eeef ",
+    "hex": "#e4eeef",
     "label": "K-135",
     "name": "Calypso Breeze"
   },
   {
-    "hex": "#244667 ",
+    "hex": "#244667",
     "label": "K-136",
     "name": "Prairie Night"
   },
   {
-    "hex": "#3e7da8 ",
+    "hex": "#3e7da8",
     "label": "K-137",
     "name": "Wakeby Beach"
   },
   {
-    "hex": "#6198c0 ",
+    "hex": "#6198c0",
     "label": "K-138",
     "name": "Bird's Egg Blue"
   },
   {
-    "hex": "#87b4d4 ",
+    "hex": "#87b4d4",
     "label": "K-139",
     "name": "Gaugin's Blue"
   },
   {
-    "hex": "#98c2df ",
+    "hex": "#98c2df",
     "label": "K-140",
     "name": "Make a Splash"
   },
   {
-    "hex": "#bbd7e7 ",
+    "hex": "#bbd7e7",
     "label": "K-141",
     "name": "Blooming Blue"
   },
   {
-    "hex": "#d7e6ec ",
+    "hex": "#d7e6ec",
     "label": "K-142",
     "name": "Bird Bath Blue"
   },
   {
-    "hex": "#e2edee ",
+    "hex": "#e2edee",
     "label": "K-143",
     "name": "Spring Dew"
   },
   {
-    "hex": "#064f77 ",
+    "hex": "#064f77",
     "label": "K-144",
     "name": "Blue By You"
   },
   {
-    "hex": "#1a84b2 ",
+    "hex": "#1a84b2",
     "label": "K-145",
     "name": "Hidden Springs"
   },
   {
-    "hex": "#4a9cc7 ",
+    "hex": "#4a9cc7",
     "label": "K-146",
     "name": "Bonaventure"
   },
   {
-    "hex": "#7bb8d9 ",
+    "hex": "#7bb8d9",
     "label": "K-147",
     "name": "Cascade Blue"
   },
   {
-    "hex": "#86c3e4 ",
+    "hex": "#86c3e4",
     "label": "K-148",
     "name": "Lupe's Lake"
   },
   {
-    "hex": "#a6d3e9 ",
+    "hex": "#a6d3e9",
     "label": "K-149",
     "name": "Sky Watch"
   },
   {
-    "hex": "#c9e4ee ",
+    "hex": "#c9e4ee",
     "label": "K-150",
     "name": "High Spirits"
   },
   {
-    "hex": "#daebef ",
+    "hex": "#daebef",
     "label": "K-151",
     "name": "Dreamy Space"
   },
   {
-    "hex": "#243a52 ",
+    "hex": "#243a52",
     "label": "K-152",
     "name": "Blazer Blue"
   },
   {
-    "hex": "#40677e ",
+    "hex": "#40677e",
     "label": "K-153",
     "name": "Blue Suede Shoes"
   },
   {
-    "hex": "#618aa3 ",
+    "hex": "#618aa3",
     "label": "K-154",
     "name": "Storm Blue Sky"
   },
   {
-    "hex": "#7ba0b7 ",
+    "hex": "#7ba0b7",
     "label": "K-155",
     "name": "Thunder Bay"
   },
   {
-    "hex": "#95bbcf ",
+    "hex": "#95bbcf",
     "label": "K-156",
     "name": "Dresden Falls"
   },
   {
-    "hex": "#a3c4d6 ",
+    "hex": "#a3c4d6",
     "label": "K-157",
     "name": "Oh Boy!"
   },
   {
-    "hex": "#bad2df ",
+    "hex": "#bad2df",
     "label": "K-158",
     "name": "Swirling Water"
   },
   {
-    "hex": "#dbe7ea ",
+    "hex": "#dbe7ea",
     "label": "K-159",
     "name": "Phantom Lake"
   },
   {
-    "hex": "#303d44 ",
+    "hex": "#303d44",
     "label": "K-160",
     "name": "Puerto Deseado"
   },
   {
-    "hex": "#506f7b ",
+    "hex": "#506f7b",
     "label": "K-161",
     "name": "Dusk Blue"
   },
   {
-    "hex": "#7493a0 ",
+    "hex": "#7493a0",
     "label": "K-162",
     "name": "Breezy Indigo"
   },
   {
-    "hex": "#94afba ",
+    "hex": "#94afba",
     "label": "K-163",
     "name": "Maracay Bay"
   },
   {
-    "hex": "#a7c0c9 ",
+    "hex": "#a7c0c9",
     "label": "K-164",
     "name": "Exotic Port"
   },
   {
-    "hex": "#b8d0d7 ",
+    "hex": "#b8d0d7",
     "label": "K-165",
     "name": "Hatteras Haze"
   },
   {
-    "hex": "#c9dade ",
+    "hex": "#c9dade",
     "label": "K-166",
     "name": "Sierra Spring"
   },
   {
-    "hex": "#dee8e8 ",
+    "hex": "#dee8e8",
     "label": "K-167",
     "name": "Cloud-wisped Sky"
   },
   {
-    "hex": "#00547b ",
+    "hex": "#00547b",
     "label": "K-168",
     "name": "Citadel Blue"
   },
   {
-    "hex": "#008eb8 ",
+    "hex": "#008eb8",
     "label": "K-169",
     "name": "Old Port"
   },
   {
-    "hex": "#26a5cb ",
+    "hex": "#26a5cb",
     "label": "K-170",
     "name": "True Sky Blue"
   },
   {
-    "hex": "#56b5d6 ",
+    "hex": "#56b5d6",
     "label": "K-171",
     "name": "Sunrise River"
   },
   {
-    "hex": "#7bc9e4 ",
+    "hex": "#7bc9e4",
     "label": "K-172",
     "name": "Paradise Bay"
   },
   {
-    "hex": "#9fd7e9 ",
+    "hex": "#9fd7e9",
     "label": "K-173",
     "name": "New Day Sky"
   },
   {
-    "hex": "#c5e6ed ",
+    "hex": "#c5e6ed",
     "label": "K-174",
     "name": "Simply Heaven "
   },
   {
-    "hex": "#e0eeed ",
+    "hex": "#e0eeed",
     "label": "K-175",
     "name": "Whispery Breeze"
   },
   {
-    "hex": "#34545e ",
+    "hex": "#34545e",
     "label": "K-176",
     "name": "Under the Sea"
   },
   {
-    "hex": "#497786 ",
+    "hex": "#497786",
     "label": "K-177",
     "name": "Ocean Blues"
   },
   {
-    "hex": "#6d99a9 ",
+    "hex": "#6d99a9",
     "label": "K-178",
     "name": "Wonderful World"
   },
   {
-    "hex": "#93b6c3 ",
+    "hex": "#93b6c3",
     "label": "K-179",
     "name": "Tropical Sea"
   },
   {
-    "hex": "#a2c5d0 ",
+    "hex": "#a2c5d0",
     "label": "K-180",
     "name": "Gift of the Sea"
   },
   {
-    "hex": "#b9d4db ",
+    "hex": "#b9d4db",
     "label": "K-181",
     "name": "Seaside Pleasure"
   },
   {
-    "hex": "#d6e4e5 ",
+    "hex": "#d6e4e5",
     "label": "K-182",
     "name": "Caribbean Sky"
   },
   {
-    "hex": "#eaefec ",
+    "hex": "#eaefec",
     "label": "K-183",
     "name": "Fair Winds"
   },
   {
-    "hex": "#1b485d ",
+    "hex": "#1b485d",
     "label": "K-184",
     "name": "Night Edition"
   },
   {
-    "hex": "#0089a6 ",
+    "hex": "#0089a6",
     "label": "K-185",
     "name": "Puerto Mio"
   },
   {
-    "hex": "#4caac4 ",
+    "hex": "#4caac4",
     "label": "K-186",
     "name": "Patch of Blue"
   },
   {
-    "hex": "#76bed3 ",
+    "hex": "#76bed3",
     "label": "K-187",
     "name": "Skyway"
   },
   {
-    "hex": "#8acdde ",
+    "hex": "#8acdde",
     "label": "K-188",
     "name": "Joyful Morning"
   },
   {
-    "hex": "#a7d9e6 ",
+    "hex": "#a7d9e6",
     "label": "K-189",
     "name": "Walking on Air"
   },
   {
-    "hex": "#bfe3e9 ",
+    "hex": "#bfe3e9",
     "label": "K-190",
     "name": "Bright Vision"
   },
   {
-    "hex": "#d1e9ec ",
+    "hex": "#d1e9ec",
     "label": "K-191",
     "name": "Gypsy Wind"
   },
   {
-    "hex": "#005c7b ",
+    "hex": "#005c7b",
     "label": "K-192",
     "name": "Sea of Midnight"
   },
   {
-    "hex": "#0094aa ",
+    "hex": "#0094aa",
     "label": "K-193",
     "name": "Navajo Turquoise"
   },
   {
-    "hex": "#1cadc2 ",
+    "hex": "#1cadc2",
     "label": "K-194",
     "name": "Bountiful Blue"
   },
   {
-    "hex": "#6ac5d5 ",
+    "hex": "#6ac5d5",
     "label": "K-195",
     "name": "Swan Lake"
   },
   {
-    "hex": "#7cd0de ",
+    "hex": "#7cd0de",
     "label": "K-196",
     "name": "Ocean Park"
   },
   {
-    "hex": "#9cdbe4 ",
+    "hex": "#9cdbe4",
     "label": "K-197",
     "name": "Fantasy Flight"
   },
   {
-    "hex": "#c6e9ec ",
+    "hex": "#c6e9ec",
     "label": "K-198",
     "name": "Inner Peace"
   },
   {
-    "hex": "#e1f1ee ",
+    "hex": "#e1f1ee",
     "label": "K-199",
     "name": "Odessa"
   },
   {
-    "hex": "#006067 ",
+    "hex": "#006067",
     "label": "K-200",
     "name": "Caribbean Dream"
   },
   {
-    "hex": "#088e95 ",
+    "hex": "#088e95",
     "label": "K-201",
     "name": "Aqua Marine"
   },
   {
-    "hex": "#4aa9b2 ",
+    "hex": "#4aa9b2",
     "label": "K-202",
     "name": "Brookside"
   },
   {
-    "hex": "#7ac3ca ",
+    "hex": "#7ac3ca",
     "label": "K-203",
     "name": "Aquavit"
   },
   {
-    "hex": "#8bd1d6 ",
+    "hex": "#8bd1d6",
     "label": "K-204",
     "name": "Pleasant View"
   },
   {
-    "hex": "#a7dddf ",
+    "hex": "#a7dddf",
     "label": "K-205",
     "name": "Christopher Coast"
   },
   {
-    "hex": "#bfe5e5 ",
+    "hex": "#bfe5e5",
     "label": "K-206",
     "name": "Swim Team"
   },
   {
-    "hex": "#d1ebea ",
+    "hex": "#d1ebea",
     "label": "K-207",
     "name": "Crystal River"
   },
   {
-    "hex": "#254b50 ",
+    "hex": "#254b50",
     "label": "K-208",
     "name": "Green Mountain Falls"
   },
   {
-    "hex": "#38757b ",
+    "hex": "#38757b",
     "label": "K-209",
     "name": "Time for Teal"
   },
   {
-    "hex": "#629ca3 ",
+    "hex": "#629ca3",
     "label": "K-210",
     "name": "Teal Lake"
   },
   {
-    "hex": "#7fb0b6 ",
+    "hex": "#7fb0b6",
     "label": "K-211",
     "name": "Turquoise Trick"
   },
   {
-    "hex": "#93c6c9 ",
+    "hex": "#93c6c9",
     "label": "K-212",
     "name": "Coastal View"
   },
   {
-    "hex": "#bcdede ",
+    "hex": "#bcdede",
     "label": "K-213",
     "name": "Aegean Accent"
   },
   {
-    "hex": "#d0e7e4 ",
+    "hex": "#d0e7e4",
     "label": "K-214",
     "name": "Essence of the Sea"
   },
   {
-    "hex": "#ddede9 ",
+    "hex": "#ddede9",
     "label": "K-215",
     "name": "Bay Breeze"
   },
   {
-    "hex": "#204749 ",
+    "hex": "#204749",
     "label": "K-216",
     "name": "Woodland Springs"
   },
   {
-    "hex": "#4c7474 ",
+    "hex": "#4c7474",
     "label": "K-217",
     "name": "Mandalay Bay"
   },
   {
-    "hex": "#6b9597 ",
+    "hex": "#6b9597",
     "label": "K-218",
     "name": "Teal Tease"
   },
   {
-    "hex": "#82a9aa ",
+    "hex": "#82a9aa",
     "label": "K-219",
     "name": "Acapulco Aqua"
   },
   {
-    "hex": "#9ec6c3 ",
+    "hex": "#9ec6c3",
     "label": "K-220",
     "name": "Teal Twilight"
   },
   {
-    "hex": "#b6d5d1 ",
+    "hex": "#b6d5d1",
     "label": "K-221",
     "name": "Seaside Accents"
   },
   {
-    "hex": "#c9e0dd ",
+    "hex": "#c9e0dd",
     "label": "K-222",
     "name": "Iced Teal"
   },
   {
-    "hex": "#e2eae6 ",
+    "hex": "#e2eae6",
     "label": "K-223",
     "name": "Bay Cruise"
   },
   {
-    "hex": "#0e535a ",
+    "hex": "#0e535a",
     "label": "K-224",
     "name": "Mountain Mist"
   },
   {
-    "hex": "#3c8583 ",
+    "hex": "#3c8583",
     "label": "K-225",
     "name": "Tropical Teal"
   },
   {
-    "hex": "#5b9e9b ",
+    "hex": "#5b9e9b",
     "label": "K-226",
     "name": "Peaceful Pond"
   },
   {
-    "hex": "#92c4c3 ",
+    "hex": "#92c4c3",
     "label": "K-227",
     "name": "Kentucky Estate"
   },
   {
-    "hex": "#a2d2d0 ",
+    "hex": "#a2d2d0",
     "label": "K-228",
     "name": "Fair Farmington"
   },
   {
-    "hex": "#badfdb ",
+    "hex": "#badfdb",
     "label": "K-229",
     "name": "Nature's Theme"
   },
   {
-    "hex": "#dcece8 ",
+    "hex": "#dcece8",
     "label": "K-230",
     "name": "Blue Green Gem"
   },
   {
-    "hex": "#e6f1ec ",
+    "hex": "#e6f1ec",
     "label": "K-231",
     "name": "Meadow Mist"
   },
   {
-    "hex": "#006668 ",
+    "hex": "#006668",
     "label": "K-232",
     "name": "Turquoise Trinket"
   },
   {
-    "hex": "#00a2a0 ",
+    "hex": "#00a2a0",
     "label": "K-233",
     "name": "Soothing Song"
   },
   {
-    "hex": "#06b8b9 ",
+    "hex": "#06b8b9",
     "label": "K-234",
     "name": "Cool Turquoise"
   },
   {
-    "hex": "#6bcecf ",
+    "hex": "#6bcecf",
     "label": "K-235",
     "name": "Oceanside Paradise"
   },
   {
-    "hex": "#7fdad9 ",
+    "hex": "#7fdad9",
     "label": "K-236",
     "name": "Turquoise Treat"
   },
   {
-    "hex": "#a5e4e2 ",
+    "hex": "#a5e4e2",
     "label": "K-237",
     "name": "Aqua Infusion"
   },
   {
-    "hex": "#bfeae6 ",
+    "hex": "#bfeae6",
     "label": "K-238",
     "name": "Baby Aqua"
   },
   {
-    "hex": "#d1efea ",
+    "hex": "#d1efea",
     "label": "K-239",
     "name": "Tender Touch"
   },
   {
-    "hex": "#006d5f ",
+    "hex": "#006d5f",
     "label": "K-240",
     "name": "Emerald Accent"
   },
   {
-    "hex": "#00a79d ",
+    "hex": "#00a79d",
     "label": "K-241",
     "name": "So Jaded"
   },
   {
-    "hex": "#00bcb5 ",
+    "hex": "#00bcb5",
     "label": "K-242",
     "name": "Alexandra Valley"
   },
   {
-    "hex": "#5bcdc7 ",
+    "hex": "#5bcdc7",
     "label": "K-243",
     "name": "May Day"
   },
   {
-    "hex": "#7ddbd4 ",
+    "hex": "#7ddbd4",
     "label": "K-244",
     "name": "Glorious Garden"
   },
   {
-    "hex": "#a4e6e0 ",
+    "hex": "#a4e6e0",
     "label": "K-245",
     "name": "Aged Aegean"
   },
   {
-    "hex": "#bfede6 ",
+    "hex": "#bfede6",
     "label": "K-246",
     "name": "Harington"
   },
   {
-    "hex": "#d0f0e9 ",
+    "hex": "#d0f0e9",
     "label": "K-247",
     "name": "Spa Springs"
   },
   {
-    "hex": "#006059 ",
+    "hex": "#006059",
     "label": "K-248",
     "name": "Enchanted Evergreen"
   },
   {
-    "hex": "#2d8e84 ",
+    "hex": "#2d8e84",
     "label": "K-249",
     "name": "Time to Grow"
   },
   {
-    "hex": "#5aada6 ",
+    "hex": "#5aada6",
     "label": "K-250",
     "name": "Picnic Haven"
   },
   {
-    "hex": "#7fc2bb ",
+    "hex": "#7fc2bb",
     "label": "K-251",
     "name": "Meadow Green"
   },
   {
-    "hex": "#9cd9d0 ",
+    "hex": "#9cd9d0",
     "label": "K-252",
     "name": "Kylemore"
   },
   {
-    "hex": "#a8dfd6 ",
+    "hex": "#a8dfd6",
     "label": "K-253",
     "name": "Mild Mallard"
   },
   {
-    "hex": "#c0e7e0 ",
+    "hex": "#c0e7e0",
     "label": "K-254",
     "name": "Prairie Princess"
   },
   {
-    "hex": "#d1ede6 ",
+    "hex": "#d1ede6",
     "label": "K-255",
     "name": "Glorianna"
   },
   {
-    "hex": "#174e46 ",
+    "hex": "#174e46",
     "label": "K-256",
     "name": "Country Meadow"
   },
   {
-    "hex": "#3b8272 ",
+    "hex": "#3b8272",
     "label": "K-257",
     "name": "Emerald Valley"
   },
   {
-    "hex": "#62a699 ",
+    "hex": "#62a699",
     "label": "K-258",
     "name": "Aged Jade"
   },
   {
-    "hex": "#82bdb1 ",
+    "hex": "#82bdb1",
     "label": "K-259",
     "name": "Green Grace"
   },
   {
-    "hex": "#96d0c3 ",
+    "hex": "#96d0c3",
     "label": "K-260",
     "name": "Kodiak Valley"
   },
   {
-    "hex": "#addbcf ",
+    "hex": "#addbcf",
     "label": "K-261",
     "name": "Irish Lass"
   },
   {
-    "hex": "#bfe4da ",
+    "hex": "#bfe4da",
     "label": "K-262",
     "name": "Summer's Secret"
   },
   {
-    "hex": "#d0ebe2 ",
+    "hex": "#d0ebe2",
     "label": "K-263",
     "name": "Mystic Glow"
   },
   {
-    "hex": "#007057 ",
+    "hex": "#007057",
     "label": "K-264",
     "name": "Shamrock Green"
   },
   {
-    "hex": "#00a283 ",
+    "hex": "#00a283",
     "label": "K-265",
     "name": "Emerald Acres"
   },
   {
-    "hex": "#55c0a9 ",
+    "hex": "#55c0a9",
     "label": "K-266",
     "name": "Jolt of Jade"
   },
   {
-    "hex": "#75ceba ",
+    "hex": "#75ceba",
     "label": "K-267",
     "name": "My Garden Party"
   },
   {
-    "hex": "#87dbc7 ",
+    "hex": "#87dbc7",
     "label": "K-268",
     "name": "Irish Isle"
   },
   {
-    "hex": "#a8e7d7 ",
+    "hex": "#a8e7d7",
     "label": "K-269",
     "name": "Jardin Jewel"
   },
   {
-    "hex": "#c6ecde ",
+    "hex": "#c6ecde",
     "label": "K-270",
     "name": "Teal Twist"
   },
   {
-    "hex": "#e2f1e6 ",
+    "hex": "#e2f1e6",
     "label": "K-271",
     "name": "Garden Sprite"
   },
   {
-    "hex": "#2a574c ",
+    "hex": "#2a574c",
     "label": "K-272",
     "name": "Woodland Fern"
   },
   {
-    "hex": "#49866e ",
+    "hex": "#49866e",
     "label": "K-273",
     "name": "Jasmine Jazz"
   },
   {
-    "hex": "#6ca793 ",
+    "hex": "#6ca793",
     "label": "K-274",
     "name": "Gardening Girl"
   },
   {
-    "hex": "#86bba8 ",
+    "hex": "#86bba8",
     "label": "K-275",
     "name": "Laurel Village"
   },
   {
-    "hex": "#9fd3bf ",
+    "hex": "#9fd3bf",
     "label": "K-276",
     "name": "Fantasy Isle"
   },
   {
-    "hex": "#b5decd ",
+    "hex": "#b5decd",
     "label": "K-277",
     "name": "Mermaid Magic"
   },
   {
-    "hex": "#d2eadd ",
+    "hex": "#d2eadd",
     "label": "K-278",
     "name": "Spring Folly"
   },
   {
-    "hex": "#dceee4 ",
+    "hex": "#dceee4",
     "label": "K-279",
     "name": "Song of Summer"
   },
   {
-    "hex": "#008b56 ",
+    "hex": "#008b56",
     "label": "K-280",
     "name": "Center Field"
   },
   {
-    "hex": "#00b080 ",
+    "hex": "#00b080",
     "label": "K-281",
     "name": "Peaceful Thyme"
   },
   {
-    "hex": "#49c49c ",
+    "hex": "#49c49c",
     "label": "K-282",
     "name": "Day in the Garden"
   },
   {
-    "hex": "#7ed8b9 ",
+    "hex": "#7ed8b9",
     "label": "K-283",
     "name": "Esmerelda"
   },
   {
-    "hex": "#91e3c9 ",
+    "hex": "#91e3c9",
     "label": "K-284",
     "name": "Summer Sonata"
   },
   {
-    "hex": "#abead5 ",
+    "hex": "#abead5",
     "label": "K-285",
     "name": "Glen Haven"
   },
   {
-    "hex": "#d3f0e4 ",
+    "hex": "#d3f0e4",
     "label": "K-286",
     "name": "Garden Soft Green"
   },
   {
-    "hex": "#e5f2e9 ",
+    "hex": "#e5f2e9",
     "label": "K-287",
     "name": "Spring Splendor"
   },
   {
-    "hex": "#236843 ",
+    "hex": "#236843",
     "label": "K-288",
     "name": "The Back Nine"
   },
   {
-    "hex": "#598f71 ",
+    "hex": "#598f71",
     "label": "K-289",
     "name": "Garden Leaf"
   },
   {
-    "hex": "#6da489 ",
+    "hex": "#6da489",
     "label": "K-290",
     "name": "Tarragon Tease"
   },
   {
-    "hex": "#91c0a9 ",
+    "hex": "#91c0a9",
     "label": "K-291",
     "name": "Pioneer Park"
   },
   {
-    "hex": "#a9d6bf ",
+    "hex": "#a9d6bf",
     "label": "K-292",
     "name": "Garden Greenery"
   },
   {
-    "hex": "#c2e3d1 ",
+    "hex": "#c2e3d1",
     "label": "K-293",
     "name": "Spring Meadow"
   },
   {
-    "hex": "#d3eadb ",
+    "hex": "#d3eadb",
     "label": "K-294",
     "name": "Island Spirit"
   },
   {
-    "hex": "#def0e4 ",
+    "hex": "#def0e4",
     "label": "K-295",
     "name": "Dream of Green"
   },
   {
-    "hex": "#1f7d43 ",
+    "hex": "#1f7d43",
     "label": "K-296",
     "name": "Forever Green"
   },
   {
-    "hex": "#48a469 ",
+    "hex": "#48a469",
     "label": "K-297",
     "name": "Summer Sumac"
   },
   {
-    "hex": "#66bb8a ",
+    "hex": "#66bb8a",
     "label": "K-298",
     "name": "Garden Variety"
   },
   {
-    "hex": "#8dd0a9 ",
+    "hex": "#8dd0a9",
     "label": "K-299",
     "name": "Sage Brush Place"
   },
   {
-    "hex": "#9de0bd ",
+    "hex": "#9de0bd",
     "label": "K-300",
     "name": "Green Pastures"
   },
   {
-    "hex": "#b0e5c9 ",
+    "hex": "#b0e5c9",
     "label": "K-301",
     "name": "Phillip's Field"
   },
   {
-    "hex": "#cfeeda ",
+    "hex": "#cfeeda",
     "label": "K-302",
     "name": "Subtle Splendor"
   },
   {
-    "hex": "#e1f1e4 ",
+    "hex": "#e1f1e4",
     "label": "K-303",
     "name": "Rites of Spring"
   },
   {
-    "hex": "#4c6c4c ",
+    "hex": "#4c6c4c",
     "label": "K-304",
     "name": "Tall Timber"
   },
   {
-    "hex": "#658e6c ",
+    "hex": "#658e6c",
     "label": "K-305",
     "name": "Woodland Sage"
   },
   {
-    "hex": "#82a98c ",
+    "hex": "#82a98c",
     "label": "K-306",
     "name": "Lakeside Pine"
   },
   {
-    "hex": "#9fc3a9 ",
+    "hex": "#9fc3a9",
     "label": "K-307",
     "name": "Aged Sage"
   },
   {
-    "hex": "#b2d4ba ",
+    "hex": "#b2d4ba",
     "label": "K-308",
     "name": "Pinetree Trail"
   },
   {
-    "hex": "#c9e2ce ",
+    "hex": "#c9e2ce",
     "label": "K-309",
     "name": "Whisper of Pine"
   },
   {
-    "hex": "#d8e9d9 ",
+    "hex": "#d8e9d9",
     "label": "K-310",
     "name": "Welcome Spring"
   },
   {
-    "hex": "#e3efe2 ",
+    "hex": "#e3efe2",
     "label": "K-311",
     "name": "Soft Mint"
   },
   {
-    "hex": "#2aa238 ",
+    "hex": "#2aa238",
     "label": "K-312",
     "name": "Jolly Holly"
   },
   {
-    "hex": "#69c365 ",
+    "hex": "#69c365",
     "label": "K-313",
     "name": "Elmvale"
   },
   {
-    "hex": "#8bd385 ",
+    "hex": "#8bd385",
     "label": "K-314",
     "name": "Amazon Trail"
   },
   {
-    "hex": "#aee2a8 ",
+    "hex": "#aee2a8",
     "label": "K-315",
     "name": "Wild Weeds"
   },
   {
-    "hex": "#bde9b9 ",
+    "hex": "#bde9b9",
     "label": "K-316",
     "name": "Althorp Park"
   },
   {
-    "hex": "#d1efc9 ",
+    "hex": "#d1efc9",
     "label": "K-317",
     "name": "Spring Leaves"
   },
   {
-    "hex": "#e2f2db ",
+    "hex": "#e2f2db",
     "label": "K-318",
     "name": "Flowing Green"
   },
   {
-    "hex": "#e9f3e2 ",
+    "hex": "#e9f3e2",
     "label": "K-319",
     "name": "Prelude to Summer"
   },
   {
-    "hex": "#5ab32c ",
+    "hex": "#5ab32c",
     "label": "K-320",
     "name": "Wilderness Retreat"
   },
   {
-    "hex": "#87cb61 ",
+    "hex": "#87cb61",
     "label": "K-321",
     "name": "Hidden Hills"
   },
   {
-    "hex": "#a0dc85 ",
+    "hex": "#a0dc85",
     "label": "K-322",
     "name": "Frog Prince"
   },
   {
-    "hex": "#bce5a1 ",
+    "hex": "#bce5a1",
     "label": "K-323",
     "name": "Sage Sensation"
   },
   {
-    "hex": "#cbecb5 ",
+    "hex": "#cbecb5",
     "label": "K-324",
     "name": "Green Light"
   },
   {
-    "hex": "#e4f2d2 ",
+    "hex": "#e4f2d2",
     "label": "K-325",
     "name": "Grassy Path"
   },
   {
-    "hex": "#ebf3db ",
+    "hex": "#ebf3db",
     "label": "K-326",
     "name": "Spring Sonnet"
   },
   {
-    "hex": "#f0f4e4 ",
+    "hex": "#f0f4e4",
     "label": "K-327",
     "name": "Misty Meadow"
   },
   {
-    "hex": "#5e903e ",
+    "hex": "#5e903e",
     "label": "K-328",
     "name": "Lily Pad Place"
   },
   {
-    "hex": "#80b063 ",
+    "hex": "#80b063",
     "label": "K-329",
     "name": "Green Jeans"
   },
   {
-    "hex": "#96c383 ",
+    "hex": "#96c383",
     "label": "K-330",
     "name": "Grand Valley"
   },
   {
-    "hex": "#b8d8a4 ",
+    "hex": "#b8d8a4",
     "label": "K-331",
     "name": "Garden Stroll"
   },
   {
-    "hex": "#c4e3b5 ",
+    "hex": "#c4e3b5",
     "label": "K-332",
     "name": "Lincoln Park"
   },
   {
-    "hex": "#d4ebc7 ",
+    "hex": "#d4ebc7",
     "label": "K-333",
     "name": "Echo of Spring"
   },
   {
-    "hex": "#e5f1da ",
+    "hex": "#e5f1da",
     "label": "K-334",
     "name": "Budding Leaf"
   },
   {
-    "hex": "#eaf2e1 ",
+    "hex": "#eaf2e1",
     "label": "K-335",
     "name": "Green Republic"
   },
   {
-    "hex": "#537640 ",
+    "hex": "#537640",
     "label": "K-336",
     "name": "Dark Drama"
   },
   {
-    "hex": "#789963 ",
+    "hex": "#789963",
     "label": "K-337",
     "name": "Jungle Birds"
   },
   {
-    "hex": "#9ab78b ",
+    "hex": "#9ab78b",
     "label": "K-338",
     "name": "Little Green Frog"
   },
   {
-    "hex": "#b8cfac ",
+    "hex": "#b8cfac",
     "label": "K-339",
     "name": "Quiet Kiwi"
   },
   {
-    "hex": "#c9ddbd ",
+    "hex": "#c9ddbd",
     "label": "K-340",
     "name": "East of Eden"
   },
   {
-    "hex": "#d5e6cb ",
+    "hex": "#d5e6cb",
     "label": "K-341",
     "name": "Springfield"
   },
   {
-    "hex": "#e1edd8 ",
+    "hex": "#e1edd8",
     "label": "K-342",
     "name": "Nature's Palette"
   },
   {
-    "hex": "#e9f0e0 ",
+    "hex": "#e9f0e0",
     "label": "K-343",
     "name": "Green Peace"
   },
   {
-    "hex": "#647146 ",
+    "hex": "#647146",
     "label": "K-344",
     "name": "Woodland Park"
   },
   {
-    "hex": "#808f67 ",
+    "hex": "#808f67",
     "label": "K-345",
     "name": "Forest Ranger"
   },
   {
-    "hex": "#8f9d73 ",
+    "hex": "#8f9d73",
     "label": "K-346",
     "name": "Cedar Lake"
   },
   {
-    "hex": "#9dad88 ",
+    "hex": "#9dad88",
     "label": "K-347",
     "name": "Majestic Mountain"
   },
   {
-    "hex": "#afbd9b ",
+    "hex": "#afbd9b",
     "label": "K-348",
     "name": "Spanish Moss"
   },
   {
-    "hex": "#c9d7b7 ",
+    "hex": "#c9d7b7",
     "label": "K-349",
     "name": "Light Loden"
   },
   {
-    "hex": "#d7e1c8 ",
+    "hex": "#d7e1c8",
     "label": "K-350",
     "name": "Villa Grove"
   },
   {
-    "hex": "#e3e9d5 ",
+    "hex": "#e3e9d5",
     "label": "K-351",
     "name": "Gardener's Delight"
   },
   {
-    "hex": "#77a534 ",
+    "hex": "#77a534",
     "label": "K-352",
     "name": "Latest Look"
   },
   {
-    "hex": "#9abf59 ",
+    "hex": "#9abf59",
     "label": "K-353",
     "name": "Sour Apple"
   },
   {
-    "hex": "#b1d07d ",
+    "hex": "#b1d07d",
     "label": "K-354",
     "name": "Lick of Lime"
   },
   {
-    "hex": "#c7de9c ",
+    "hex": "#c7de9c",
     "label": "K-355",
     "name": "Snappy Green"
   },
   {
-    "hex": "#d8eab6 ",
+    "hex": "#d8eab6",
     "label": "K-356",
     "name": "Point Pleasant Heights"
   },
   {
-    "hex": "#e6f0cc ",
+    "hex": "#e6f0cc",
     "label": "K-357",
     "name": "Glory of Spring"
   },
   {
-    "hex": "#ecf2d6 ",
+    "hex": "#ecf2d6",
     "label": "K-358",
     "name": "Kiwi Kiss"
   },
   {
-    "hex": "#f0f3de ",
+    "hex": "#f0f3de",
     "label": "K-359",
     "name": "Spring Promise"
   },
   {
-    "hex": "#7e8947 ",
+    "hex": "#7e8947",
     "label": "K-360",
     "name": "Limerick Trick"
   },
   {
-    "hex": "#8d9a5b ",
+    "hex": "#8d9a5b",
     "label": "K-361",
     "name": "Jean's Greens"
   },
   {
-    "hex": "#a9b57d ",
+    "hex": "#a9b57d",
     "label": "K-362",
     "name": "Spring Ahead"
   },
   {
-    "hex": "#c1cb9a ",
+    "hex": "#c1cb9a",
     "label": "K-363",
     "name": "English Countryside"
   },
   {
-    "hex": "#cedaac ",
+    "hex": "#cedaac",
     "label": "K-364",
     "name": "Green of Spring"
   },
   {
-    "hex": "#d7e1b9 ",
+    "hex": "#d7e1b9",
     "label": "K-365",
     "name": "Pick of the Meadow"
   },
   {
-    "hex": "#e7ecd1 ",
+    "hex": "#e7ecd1",
     "label": "K-366",
     "name": "Glimpse of Spring"
   },
   {
-    "hex": "#ecefdb ",
+    "hex": "#ecefdb",
     "label": "K-367",
     "name": "New Green"
   },
   {
-    "hex": "#77973a ",
+    "hex": "#77973a",
     "label": "K-368",
     "name": "Luscious Lime"
   },
   {
-    "hex": "#97b35d ",
+    "hex": "#97b35d",
     "label": "K-369",
     "name": "Green Apple Peels"
   },
   {
-    "hex": "#aec77e ",
+    "hex": "#aec77e",
     "label": "K-370",
     "name": "Limeade"
   },
   {
-    "hex": "#c3d699 ",
+    "hex": "#c3d699",
     "label": "K-371",
     "name": "Spring Has Sprung"
   },
   {
-    "hex": "#d3e5b2 ",
+    "hex": "#d3e5b2",
     "label": "K-372",
     "name": "Loire Valley"
   },
   {
-    "hex": "#dceabf ",
+    "hex": "#dceabf",
     "label": "K-373",
     "name": "Green Acres"
   },
   {
-    "hex": "#e6efcf ",
+    "hex": "#e6efcf",
     "label": "K-374",
     "name": "Perennial Path"
   },
   {
-    "hex": "#ecf1d8 ",
+    "hex": "#ecf1d8",
     "label": "K-375",
     "name": "Soft Fern"
   },
   {
-    "hex": "#a1be1a ",
+    "hex": "#a1be1a",
     "label": "K-376",
     "name": "Sporting Green"
   },
   {
-    "hex": "#afd54f ",
+    "hex": "#afd54f",
     "label": "K-377",
     "name": "Burst of Lime"
   },
   {
-    "hex": "#c8e17b ",
+    "hex": "#c8e17b",
     "label": "K-378",
     "name": "Fresh Lettuce"
   },
   {
-    "hex": "#dbeba1 ",
+    "hex": "#dbeba1",
     "label": "K-379",
     "name": "Peeled Pistacchio"
   },
   {
-    "hex": "#e5f1b7 ",
+    "hex": "#e5f1b7",
     "label": "K-380",
     "name": "Chelsea Garden"
   },
   {
-    "hex": "#ebf1c5 ",
+    "hex": "#ebf1c5",
     "label": "K-381",
     "name": "Spring Glen"
   },
   {
-    "hex": "#f0f4d4 ",
+    "hex": "#f0f4d4",
     "label": "K-382",
     "name": "Joy of Nature"
   },
   {
-    "hex": "#f3f5de ",
+    "hex": "#f3f5de",
     "label": "K-383",
     "name": "Soft Spring"
   },
   {
-    "hex": "#97a631 ",
+    "hex": "#97a631",
     "label": "K-384",
     "name": "Parisan Park"
   },
   {
-    "hex": "#aebc58 ",
+    "hex": "#aebc58",
     "label": "K-385",
     "name": "Jive Clive"
   },
   {
-    "hex": "#c8d27e ",
+    "hex": "#c8d27e",
     "label": "K-386",
     "name": "Alligator Alley"
   },
   {
-    "hex": "#d5dd96 ",
+    "hex": "#d5dd96",
     "label": "K-387",
     "name": "Spring Garden Walk"
   },
   {
-    "hex": "#e4eab3 ",
+    "hex": "#e4eab3",
     "label": "K-388",
     "name": "Sparkling Spring"
   },
   {
-    "hex": "#e8edbe ",
+    "hex": "#e8edbe",
     "label": "K-389",
     "name": "Spring Bounty"
   },
   {
-    "hex": "#eff1cd ",
+    "hex": "#eff1cd",
     "label": "K-390",
     "name": "Soft Shamrock"
   },
   {
-    "hex": "#f2f2d6 ",
+    "hex": "#f2f2d6",
     "label": "K-391",
     "name": "Burst of Spring"
   },
   {
-    "hex": "#c8d62d ",
+    "hex": "#c8d62d",
     "label": "K-392",
     "name": "Sour Lime"
   },
   {
-    "hex": "#d4dd4c ",
+    "hex": "#d4dd4c",
     "label": "K-393",
     "name": "Wow"
   },
   {
-    "hex": "#d6e36f ",
+    "hex": "#d6e36f",
     "label": "K-394",
     "name": "Lime Ricky"
   },
   {
-    "hex": "#dce787 ",
+    "hex": "#dce787",
     "label": "K-395",
     "name": "Neon Lights"
   },
   {
-    "hex": "#dfe7a0 ",
+    "hex": "#dfe7a0",
     "label": "K-396",
     "name": "Fresh Sprout"
   },
   {
-    "hex": "#eaefc0 ",
+    "hex": "#eaefc0",
     "label": "K-397",
     "name": "Green Mile"
   },
   {
-    "hex": "#eeefc9 ",
+    "hex": "#eeefc9",
     "label": "K-398",
     "name": "Chipper Tint"
   },
   {
-    "hex": "#f3f4d9 ",
+    "hex": "#f3f4d9",
     "label": "K-399",
     "name": "Green Whisp"
   },
   {
-    "hex": "#707145 ",
+    "hex": "#707145",
     "label": "K-400",
     "name": "Tuscany Hillside"
   },
   {
-    "hex": "#888b5d ",
+    "hex": "#888b5d",
     "label": "K-401",
     "name": "Point Verde"
   },
   {
-    "hex": "#9b9e71 ",
+    "hex": "#9b9e71",
     "label": "K-402",
     "name": "Aged Avocado"
   },
   {
-    "hex": "#aaad86 ",
+    "hex": "#aaad86",
     "label": "K-403",
     "name": "Portsmouth Olive"
   },
   {
-    "hex": "#babd9a ",
+    "hex": "#babd9a",
     "label": "K-404",
     "name": "Golden Shores"
   },
   {
-    "hex": "#ced1ac ",
+    "hex": "#ced1ac",
     "label": "K-405",
     "name": "Golden Chartreuse"
   },
   {
-    "hex": "#e0e2c7 ",
+    "hex": "#e0e2c7",
     "label": "K-406",
     "name": "Spring Frolic"
   },
   {
-    "hex": "#e8e9d4 ",
+    "hex": "#e8e9d4",
     "label": "K-407",
     "name": "A New Leaf"
   },
   {
-    "hex": "#7c7947 ",
+    "hex": "#7c7947",
     "label": "K-408",
     "name": "Cedar Edge"
   },
   {
-    "hex": "#8c8a5b ",
+    "hex": "#8c8a5b",
     "label": "K-409",
     "name": "Aged Olive"
   },
   {
-    "hex": "#9a9764 ",
+    "hex": "#9a9764",
     "label": "K-410",
     "name": "Retro Avocado"
   },
   {
-    "hex": "#a8a77b ",
+    "hex": "#a8a77b",
     "label": "K-411",
     "name": "Mossy Log"
   },
   {
-    "hex": "#bdbc93 ",
+    "hex": "#bdbc93",
     "label": "K-412",
     "name": "Jungle Cane"
   },
   {
-    "hex": "#d2d2a9 ",
+    "hex": "#d2d2a9",
     "label": "K-413",
     "name": "Hillsmere"
   },
   {
-    "hex": "#e2e0c2 ",
+    "hex": "#e2e0c2",
     "label": "K-414",
     "name": "Villa Nova"
   },
   {
-    "hex": "#e9e8d0 ",
+    "hex": "#e9e8d0",
     "label": "K-415",
     "name": "Arbor Field"
   },
   {
-    "hex": "#959143 ",
+    "hex": "#959143",
     "label": "K-416",
     "name": "Spring Fancy"
   },
   {
-    "hex": "#a29f54 ",
+    "hex": "#a29f54",
     "label": "K-417",
     "name": "Halls of Ivy"
   },
   {
-    "hex": "#b0ac62 ",
+    "hex": "#b0ac62",
     "label": "K-418",
     "name": "Sweet Celery"
   },
   {
-    "hex": "#bbba77 ",
+    "hex": "#bbba77",
     "label": "K-419",
     "name": "Young Green"
   },
   {
-    "hex": "#cdcb91 ",
+    "hex": "#cdcb91",
     "label": "K-420",
     "name": "Frontenac Hills"
   },
   {
-    "hex": "#dcdcaa ",
+    "hex": "#dcdcaa",
     "label": "K-421",
     "name": "Spring Farm"
   },
   {
-    "hex": "#e9e8c2 ",
+    "hex": "#e9e8c2",
     "label": "K-422",
     "name": "Sunny Knoll"
   },
   {
-    "hex": "#eeedd0 ",
+    "hex": "#eeedd0",
     "label": "K-423",
     "name": "White Marsh"
   },
   {
-    "hex": "#9b9b39 ",
+    "hex": "#9b9b39",
     "label": "K-424",
     "name": "National Forest"
   },
   {
-    "hex": "#bfb95c ",
+    "hex": "#bfb95c",
     "label": "K-425",
     "name": "Terra Verde"
   },
   {
-    "hex": "#d2cc7a ",
+    "hex": "#d2cc7a",
     "label": "K-426",
     "name": "Italian Olive"
   },
   {
-    "hex": "#d7d288 ",
+    "hex": "#d7d288",
     "label": "K-427",
     "name": "Garden Promenade"
   },
   {
-    "hex": "#e1dd9e ",
+    "hex": "#e1dd9e",
     "label": "K-428",
     "name": "Meadow Marsh"
   },
   {
-    "hex": "#ede8b5 ",
+    "hex": "#ede8b5",
     "label": "K-429",
     "name": "Sprig of Sage"
   },
   {
-    "hex": "#f0edc4 ",
+    "hex": "#f0edc4",
     "label": "K-430",
     "name": "Provincial Garden"
   },
   {
-    "hex": "#f3f0d0 ",
+    "hex": "#f3f0d0",
     "label": "K-431",
     "name": "Spirit Island"
   },
   {
-    "hex": "#cdbc09 ",
+    "hex": "#cdbc09",
     "label": "K-432",
     "name": "Miss Marigold"
   },
   {
-    "hex": "#e9d959 ",
+    "hex": "#e9d959",
     "label": "K-433",
     "name": "Sun Bright"
   },
   {
-    "hex": "#ecdf7a ",
+    "hex": "#ecdf7a",
     "label": "K-434",
     "name": "Bold Gold"
   },
   {
-    "hex": "#f2ea9c ",
+    "hex": "#f2ea9c",
     "label": "K-435",
     "name": "Golden Treasure"
   },
   {
-    "hex": "#faf2b8 ",
+    "hex": "#faf2b8",
     "label": "K-436",
     "name": "Sun Fun"
   },
   {
-    "hex": "#f8f3c5 ",
+    "hex": "#f8f3c5",
     "label": "K-437",
     "name": "Gold Gleam"
   },
   {
-    "hex": "#f7f4d8 ",
+    "hex": "#f7f4d8",
     "label": "K-438",
     "name": "Golden Season"
   },
   {
-    "hex": "#f6f4e1 ",
+    "hex": "#f6f4e1",
     "label": "K-439",
     "name": "Summer Fun"
   },
   {
-    "hex": "#a09238 ",
+    "hex": "#a09238",
     "label": "K-440",
     "name": "Ornamental Grass"
   },
   {
-    "hex": "#bbac59 ",
+    "hex": "#bbac59",
     "label": "K-441",
     "name": "Garden Element"
   },
   {
-    "hex": "#d2c680 ",
+    "hex": "#d2c680",
     "label": "K-442",
     "name": "Avalon"
   },
   {
-    "hex": "#ded49a ",
+    "hex": "#ded49a",
     "label": "K-443",
     "name": "Divine Vine"
   },
   {
-    "hex": "#ebe4b4 ",
+    "hex": "#ebe4b4",
     "label": "K-444",
     "name": "Meadowland"
   },
   {
-    "hex": "#f3eecb ",
+    "hex": "#f3eecb",
     "label": "K-445",
     "name": "Harmony Hills"
   },
   {
-    "hex": "#f3efd4 ",
+    "hex": "#f3efd4",
     "label": "K-446",
     "name": "Kindred Spirit"
   },
   {
-    "hex": "#f5f3df ",
+    "hex": "#f5f3df",
     "label": "K-447",
     "name": "Angel Kiss"
   },
   {
-    "hex": "#7a7139 ",
+    "hex": "#7a7139",
     "label": "K-448",
     "name": "Veradale"
   },
   {
-    "hex": "#a0955d ",
+    "hex": "#a0955d",
     "label": "K-449",
     "name": "Olive Oil"
   },
   {
-    "hex": "#b3a772 ",
+    "hex": "#b3a772",
     "label": "K-450",
     "name": "Sheffield"
   },
   {
-    "hex": "#c1b78a ",
+    "hex": "#c1b78a",
     "label": "K-451",
     "name": "Bamboo Shoot"
   },
   {
-    "hex": "#cfc89f ",
+    "hex": "#cfc89f",
     "label": "K-452",
     "name": "Gold Mountain"
   },
   {
-    "hex": "#e0d8b4 ",
+    "hex": "#e0d8b4",
     "label": "K-453",
     "name": "Banana Cream"
   },
   {
-    "hex": "#e8e2c4 ",
+    "hex": "#e8e2c4",
     "label": "K-454",
     "name": "Pale Papyrus"
   },
   {
-    "hex": "#f0edda ",
+    "hex": "#f0edda",
     "label": "K-455",
     "name": "Windswept Sails"
   },
   {
-    "hex": "#baa736 ",
+    "hex": "#baa736",
     "label": "K-456",
     "name": "The Open Range"
   },
   {
-    "hex": "#d0be55 ",
+    "hex": "#d0be55",
     "label": "K-457",
     "name": "September Sun"
   },
   {
-    "hex": "#e0d27d ",
+    "hex": "#e0d27d",
     "label": "K-458",
     "name": "Australian Outlook"
   },
   {
-    "hex": "#ebde99 ",
+    "hex": "#ebde99",
     "label": "K-459",
     "name": "Goldiluxe"
   },
   {
-    "hex": "#f3eab3 ",
+    "hex": "#f3eab3",
     "label": "K-460",
     "name": "Honey Heaven"
   },
   {
-    "hex": "#f4efc8 ",
+    "hex": "#f4efc8",
     "label": "K-461",
     "name": "Happy Honey"
   },
   {
-    "hex": "#f5f1d4 ",
+    "hex": "#f5f1d4",
     "label": "K-462",
     "name": "Natural Linen"
   },
   {
-    "hex": "#f4f2dd ",
+    "hex": "#f4f2dd",
     "label": "K-463",
     "name": "Thickened Cream"
   },
   {
-    "hex": "#ffd704 ",
+    "hex": "#ffd704",
     "label": "K-464",
     "name": "Under the Sun"
   },
   {
-    "hex": "#ffe449 ",
+    "hex": "#ffe449",
     "label": "K-465",
     "name": "Rajah Gold"
   },
   {
-    "hex": "#ffeb7a ",
+    "hex": "#ffeb7a",
     "label": "K-466",
     "name": "Summer Yellow"
   },
   {
-    "hex": "#feee91 ",
+    "hex": "#feee91",
     "label": "K-467",
     "name": "Lemon Burst"
   },
   {
-    "hex": "#faf2b3 ",
+    "hex": "#faf2b3",
     "label": "K-468",
     "name": "Rise and Shine"
   },
   {
-    "hex": "#f9f3c4 ",
+    "hex": "#f9f3c4",
     "label": "K-469",
     "name": "Sunshiny"
   },
   {
-    "hex": "#f7f3d1 ",
+    "hex": "#f7f3d1",
     "label": "K-470",
     "name": "Sunny Companion"
   },
   {
-    "hex": "#f7f5dc ",
+    "hex": "#f7f5dc",
     "label": "K-471",
     "name": "Summer Style"
   },
   {
-    "hex": "#ffcc00 ",
+    "hex": "#ffcc00",
     "label": "K-472",
     "name": "Golden Ray"
   },
   {
-    "hex": "#ffda40 ",
+    "hex": "#ffda40",
     "label": "K-473",
     "name": "Sunflower Petal"
   },
   {
-    "hex": "#ffe372 ",
+    "hex": "#ffe372",
     "label": "K-474",
     "name": "Country Sun"
   },
   {
-    "hex": "#ffec95 ",
+    "hex": "#ffec95",
     "label": "K-475",
     "name": "Saffron Smile"
   },
   {
-    "hex": "#fcf1b7 ",
+    "hex": "#fcf1b7",
     "label": "K-476",
     "name": "Lemon Rose"
   },
   {
-    "hex": "#f9f0c3 ",
+    "hex": "#f9f0c3",
     "label": "K-477",
     "name": "Sunny Sanibel"
   },
   {
-    "hex": "#f8f4d8 ",
+    "hex": "#f8f4d8",
     "label": "K-478",
     "name": "Shining Bright"
   },
   {
-    "hex": "#f7f5e1 ",
+    "hex": "#f7f5e1",
     "label": "K-479",
     "name": "Soft Honey"
   },
   {
-    "hex": "#bc9b32 ",
+    "hex": "#bc9b32",
     "label": "K-480",
     "name": "Golden Rattan"
   },
   {
-    "hex": "#cdae4e ",
+    "hex": "#cdae4e",
     "label": "K-481",
     "name": "Slip into Sunset"
   },
   {
-    "hex": "#dbbc61 ",
+    "hex": "#dbbc61",
     "label": "K-482",
     "name": "The Outback"
   },
   {
-    "hex": "#ead38f ",
+    "hex": "#ead38f",
     "label": "K-483",
     "name": "Honey Mustard"
   },
   {
-    "hex": "#f1e0a5 ",
+    "hex": "#f1e0a5",
     "label": "K-484",
     "name": "Sea Oats"
   },
   {
-    "hex": "#f4e7b8 ",
+    "hex": "#f4e7b8",
     "label": "K-485",
     "name": "Sunny Disposition"
   },
   {
-    "hex": "#f9f2cf ",
+    "hex": "#f9f2cf",
     "label": "K-486",
     "name": "Yuma Sand"
   },
   {
-    "hex": "#f8f3da ",
+    "hex": "#f8f3da",
     "label": "K-487",
     "name": "Irish Linen"
   },
   {
-    "hex": "#a98840 ",
+    "hex": "#a98840",
     "label": "K-488",
     "name": "Gold Strike"
   },
   {
-    "hex": "#bc9d58 ",
+    "hex": "#bc9d58",
     "label": "K-489",
     "name": "Botanica Gold"
   },
   {
-    "hex": "#c5a863 ",
+    "hex": "#c5a863",
     "label": "K-490",
     "name": "Sunshine Yellow"
   },
   {
-    "hex": "#d2b87b ",
+    "hex": "#d2b87b",
     "label": "K-491",
     "name": "Star Fire"
   },
   {
-    "hex": "#e2cc9a ",
+    "hex": "#e2cc9a",
     "label": "K-492",
     "name": "Pale Pollen"
   },
   {
-    "hex": "#ecdbad ",
+    "hex": "#ecdbad",
     "label": "K-493",
     "name": "Sun Glory"
   },
   {
-    "hex": "#f1e4bf ",
+    "hex": "#f1e4bf",
     "label": "K-494",
     "name": "French Sonnet"
   },
   {
-    "hex": "#f3ecd4 ",
+    "hex": "#f3ecd4",
     "label": "K-495",
     "name": "Pale Ivory"
   },
   {
-    "hex": "#f2ba2b ",
+    "hex": "#f2ba2b",
     "label": "K-496",
     "name": "Devonshire"
   },
   {
-    "hex": "#f9d154 ",
+    "hex": "#f9d154",
     "label": "K-497",
     "name": "Sunland Park"
   },
   {
-    "hex": "#fbdc75 ",
+    "hex": "#fbdc75",
     "label": "K-498",
     "name": "Tons of Sun"
   },
   {
-    "hex": "#fde38d ",
+    "hex": "#fde38d",
     "label": "K-499",
     "name": "Sunlit Sand"
   },
   {
-    "hex": "#fdf0b5 ",
+    "hex": "#fdf0b5",
     "label": "K-500",
     "name": "Cream Custard"
   },
   {
-    "hex": "#fcf2be ",
+    "hex": "#fcf2be",
     "label": "K-501",
     "name": "Autumn Valley"
   },
   {
-    "hex": "#faf3cd ",
+    "hex": "#faf3cd",
     "label": "K-502",
     "name": "Spring Fever"
   },
   {
-    "hex": "#f8f4d9 ",
+    "hex": "#f8f4d9",
     "label": "K-503",
     "name": "Lynne Acres"
   },
   {
-    "hex": "#eab41e ",
+    "hex": "#eab41e",
     "label": "K-504",
     "name": "Dried Mustard"
   },
   {
-    "hex": "#f6ca51 ",
+    "hex": "#f6ca51",
     "label": "K-505",
     "name": "Somerton"
   },
   {
-    "hex": "#f9d877 ",
+    "hex": "#f9d877",
     "label": "K-506",
     "name": "Mayan Maize"
   },
   {
-    "hex": "#fce59c ",
+    "hex": "#fce59c",
     "label": "K-507",
     "name": "Southern Exposure"
   },
   {
-    "hex": "#fbedb3 ",
+    "hex": "#fbedb3",
     "label": "K-508",
     "name": "Senegal Sun"
   },
   {
-    "hex": "#fbf1c6 ",
+    "hex": "#fbf1c6",
     "label": "K-509",
     "name": "Fun in the Sun"
   },
   {
-    "hex": "#f9f3d3 ",
+    "hex": "#f9f3d3",
     "label": "K-510",
     "name": "Vanilla Almond"
   },
   {
-    "hex": "#f8f4dd ",
+    "hex": "#f8f4dd",
     "label": "K-511",
     "name": "Evening Moon"
   },
   {
-    "hex": "#ffc300 ",
+    "hex": "#ffc300",
     "label": "K-512",
     "name": "Inca Gold"
   },
   {
-    "hex": "#ffd23b ",
+    "hex": "#ffd23b",
     "label": "K-513",
     "name": "Golden Girl"
   },
   {
-    "hex": "#ffe175 ",
+    "hex": "#ffe175",
     "label": "K-514",
     "name": "Ski Valley"
   },
   {
-    "hex": "#ffe898 ",
+    "hex": "#ffe898",
     "label": "K-515",
     "name": "Solid Gold"
   },
   {
-    "hex": "#ffeeb1 ",
+    "hex": "#ffeeb1",
     "label": "K-516",
     "name": "Golden Aura"
   },
   {
-    "hex": "#fcf0c0 ",
+    "hex": "#fcf0c0",
     "label": "K-517",
     "name": "Sundrenched"
   },
   {
-    "hex": "#faf3d4 ",
+    "hex": "#faf3d4",
     "label": "K-518",
     "name": "Liquid Light"
   },
   {
-    "hex": "#f7f5e4 ",
+    "hex": "#f7f5e4",
     "label": "K-519",
     "name": "Firefly Flicker"
   },
   {
-    "hex": "#f0a90a ",
+    "hex": "#f0a90a",
     "label": "K-520",
     "name": "Golden Autumn"
   },
   {
-    "hex": "#f8ba38 ",
+    "hex": "#f8ba38",
     "label": "K-521",
     "name": "Antique Gold"
   },
   {
-    "hex": "#ffcc61 ",
+    "hex": "#ffcc61",
     "label": "K-522",
     "name": "Burnished Sun"
   },
   {
-    "hex": "#ffdb8c ",
+    "hex": "#ffdb8c",
     "label": "K-523",
     "name": "Hawaiian Honey"
   },
   {
-    "hex": "#ffe7a7 ",
+    "hex": "#ffe7a7",
     "label": "K-524",
     "name": "Sommerset"
   },
   {
-    "hex": "#ffedba ",
+    "hex": "#ffedba",
     "label": "K-525",
     "name": "Wild Honey"
   },
   {
-    "hex": "#fdf0ca ",
+    "hex": "#fdf0ca",
     "label": "K-526",
     "name": "Sprinkled with Summer"
   },
   {
-    "hex": "#fbf2d6 ",
+    "hex": "#fbf2d6",
     "label": "K-527",
     "name": "Lunar Luxury"
   },
   {
-    "hex": "#d29c31 ",
+    "hex": "#d29c31",
     "label": "K-528",
     "name": "Field Gear"
   },
   {
-    "hex": "#e1b150 ",
+    "hex": "#e1b150",
     "label": "K-529",
     "name": "Serengeti Song"
   },
   {
-    "hex": "#efc674 ",
+    "hex": "#efc674",
     "label": "K-530",
     "name": "Sari Suit"
   },
   {
-    "hex": "#f8d897 ",
+    "hex": "#f8d897",
     "label": "K-531",
     "name": "Creased Khaki"
   },
   {
-    "hex": "#fbe4ab ",
+    "hex": "#fbe4ab",
     "label": "K-532",
     "name": "Natural Raffia"
   },
   {
-    "hex": "#faebbf ",
+    "hex": "#faebbf",
     "label": "K-533",
     "name": "Home and Hearth"
   },
   {
-    "hex": "#f8f0d6 ",
+    "hex": "#f8f0d6",
     "label": "K-534",
     "name": "Shredded Wheat"
   },
   {
-    "hex": "#f7f4e6 ",
+    "hex": "#f7f4e6",
     "label": "K-535",
     "name": "Washed Canvas"
   },
   {
-    "hex": "#ca933e ",
+    "hex": "#ca933e",
     "label": "K-536",
     "name": "Chapultepec"
   },
   {
-    "hex": "#dba755 ",
+    "hex": "#dba755",
     "label": "K-537",
     "name": "Great Gaucho"
   },
   {
-    "hex": "#e8bb73 ",
+    "hex": "#e8bb73",
     "label": "K-538",
     "name": "West Warwick"
   },
   {
-    "hex": "#f0c989 ",
+    "hex": "#f0c989",
     "label": "K-539",
     "name": "Hacienda Clay"
   },
   {
-    "hex": "#fadeaa ",
+    "hex": "#fadeaa",
     "label": "K-540",
     "name": "Sea of Sand"
   },
   {
-    "hex": "#fbe9c3 ",
+    "hex": "#fbe9c3",
     "label": "K-541",
     "name": "Clean Canvas"
   },
   {
-    "hex": "#f9f0da ",
+    "hex": "#f9f0da",
     "label": "K-542",
     "name": "Magnolia Bloom"
   },
   {
-    "hex": "#f7f3e6 ",
+    "hex": "#f7f3e6",
     "label": "K-543",
     "name": "Moon Magic"
   },
   {
-    "hex": "#ffb400 ",
+    "hex": "#ffb400",
     "label": "K-544",
     "name": "Bright Lily"
   },
   {
-    "hex": "#ffc82b ",
+    "hex": "#ffc82b",
     "label": "K-545",
     "name": "Goldfinch"
   },
   {
-    "hex": "#ffd668 ",
+    "hex": "#ffd668",
     "label": "K-546",
     "name": "Bright Fires"
   },
   {
-    "hex": "#ffe28f ",
+    "hex": "#ffe28f",
     "label": "K-547",
     "name": "Tigger's Tail"
   },
   {
-    "hex": "#ffeaa7 ",
+    "hex": "#ffeaa7",
     "label": "K-548",
     "name": "Bee Balm"
   },
   {
-    "hex": "#ffedba ",
+    "hex": "#ffedba",
     "label": "K-549",
     "name": "Tangerine Twist"
   },
   {
-    "hex": "#fcf0ca ",
+    "hex": "#fcf0ca",
     "label": "K-550",
     "name": "Cornmeal"
   },
   {
-    "hex": "#f9f4df ",
+    "hex": "#f9f4df",
     "label": "K-551",
     "name": "Buttered Up"
   },
   {
-    "hex": "#ffaa00 ",
+    "hex": "#ffaa00",
     "label": "K-552",
     "name": "Florida Orange"
   },
   {
-    "hex": "#ffba40 ",
+    "hex": "#ffba40",
     "label": "K-553",
     "name": "Firefly Glow"
   },
   {
-    "hex": "#ffc65a ",
+    "hex": "#ffc65a",
     "label": "K-554",
     "name": "Orange Spark"
   },
   {
-    "hex": "#ffd98d ",
+    "hex": "#ffd98d",
     "label": "K-555",
     "name": "Dreamsicle"
   },
   {
-    "hex": "#ffe7ad ",
+    "hex": "#ffe7ad",
     "label": "K-556",
     "name": "Fairy Glitter"
   },
   {
-    "hex": "#feecbf ",
+    "hex": "#feecbf",
     "label": "K-557",
     "name": "Sparkle Tint"
   },
   {
-    "hex": "#fceec8 ",
+    "hex": "#fceec8",
     "label": "K-558",
     "name": "Tinkerbell Trail "
   },
   {
-    "hex": "#faf1d7 ",
+    "hex": "#faf1d7",
     "label": "K-559",
     "name": "Apricot Mousse"
   },
   {
-    "hex": "#ff9a05 ",
+    "hex": "#ff9a05",
     "label": "K-560",
     "name": "Monarch Wing"
   },
   {
-    "hex": "#ffb239 ",
+    "hex": "#ffb239",
     "label": "K-561",
     "name": "Pumpkin Harvest"
   },
   {
-    "hex": "#ffc465 ",
+    "hex": "#ffc465",
     "label": "K-562",
     "name": "Autumn's Charm"
   },
   {
-    "hex": "#ffd280 ",
+    "hex": "#ffd280",
     "label": "K-563",
     "name": "Summer Sherbert"
   },
   {
-    "hex": "#ffe1a2 ",
+    "hex": "#ffe1a2",
     "label": "K-564",
     "name": "Elberta Peaches"
   },
   {
-    "hex": "#fdedc3 ",
+    "hex": "#fdedc3",
     "label": "K-565",
     "name": "Zahria"
   },
   {
-    "hex": "#fbf0d0 ",
+    "hex": "#fbf0d0",
     "label": "K-566",
     "name": "Apricotta"
   },
   {
-    "hex": "#f9f2dc ",
+    "hex": "#f9f2dc",
     "label": "K-567",
     "name": "Vanilla View"
   },
   {
-    "hex": "#cb8135 ",
+    "hex": "#cb8135",
     "label": "K-568",
     "name": "Mandarin Grove"
   },
   {
-    "hex": "#e09c52 ",
+    "hex": "#e09c52",
     "label": "K-569",
     "name": "Autumn Beauty"
   },
   {
-    "hex": "#f0b87a ",
+    "hex": "#f0b87a",
     "label": "K-570",
     "name": "Seville Orange"
   },
   {
-    "hex": "#f8c791 ",
+    "hex": "#f8c791",
     "label": "K-571",
     "name": "Citrus Sherbert"
   },
   {
-    "hex": "#fedcac ",
+    "hex": "#fedcac",
     "label": "K-572",
     "name": "Coral Beach"
   },
   {
-    "hex": "#fce3be ",
+    "hex": "#fce3be",
     "label": "K-573",
     "name": "Such a Peach"
   },
   {
-    "hex": "#f9edd4 ",
+    "hex": "#f9edd4",
     "label": "K-574",
     "name": "Rave Rachel"
   },
   {
-    "hex": "#f7f2e5 ",
+    "hex": "#f7f2e5",
     "label": "K-575",
     "name": "Soft Shoulders"
   },
   {
-    "hex": "#fd8323 ",
+    "hex": "#fd8323",
     "label": "K-576",
     "name": "Haley's Comet"
   },
   {
-    "hex": "#ffa348 ",
+    "hex": "#ffa348",
     "label": "K-577",
     "name": "Tangelo Anna"
   },
   {
-    "hex": "#ffb76a ",
+    "hex": "#ffb76a",
     "label": "K-578",
     "name": "Sweet Michelle"
   },
   {
-    "hex": "#ffd096 ",
+    "hex": "#ffd096",
     "label": "K-579",
     "name": "Mirasol Paula"
   },
   {
-    "hex": "#ffdeab ",
+    "hex": "#ffdeab",
     "label": "K-580",
     "name": "Ariana"
   },
   {
-    "hex": "#fee7c0 ",
+    "hex": "#fee7c0",
     "label": "K-581",
     "name": "Proud Mary"
   },
   {
-    "hex": "#fcedcf ",
+    "hex": "#fcedcf",
     "label": "K-582",
     "name": "Quiche Lorraine"
   },
   {
-    "hex": "#f9efd9 ",
+    "hex": "#f9efd9",
     "label": "K-583",
     "name": "Christi Cream"
   },
   {
-    "hex": "#d9863a ",
+    "hex": "#d9863a",
     "label": "K-584",
     "name": "Bergamot Orange"
   },
   {
-    "hex": "#e99d56 ",
+    "hex": "#e99d56",
     "label": "K-585",
     "name": "Amber Autumn"
   },
   {
-    "hex": "#f2b276 ",
+    "hex": "#f2b276",
     "label": "K-586",
     "name": "Sirena Sun"
   },
   {
-    "hex": "#fcc996 ",
+    "hex": "#fcc996",
     "label": "K-587",
     "name": "Baltic Amber"
   },
   {
-    "hex": "#ffd8ab ",
+    "hex": "#ffd8ab",
     "label": "K-588",
     "name": "Amber Moon"
   },
   {
-    "hex": "#fee1bc ",
+    "hex": "#fee1bc",
     "label": "K-589",
     "name": "Moonlight Beach"
   },
   {
-    "hex": "#fae9cf ",
+    "hex": "#fae9cf",
     "label": "K-590",
     "name": "Cumberland Cream"
   },
   {
-    "hex": "#faf0de ",
+    "hex": "#faf0de",
     "label": "K-591",
     "name": "Moon Maiden"
   },
   {
-    "hex": "#e87434 ",
+    "hex": "#e87434",
     "label": "K-592",
     "name": "Bright Bittersweet"
   },
   {
-    "hex": "#fe9150 ",
+    "hex": "#fe9150",
     "label": "K-593",
     "name": "Autumn Splendor"
   },
   {
-    "hex": "#ffaa76 ",
+    "hex": "#ffaa76",
     "label": "K-594",
     "name": "Coral Canyon"
   },
   {
-    "hex": "#ffc599 ",
+    "hex": "#ffc599",
     "label": "K-595",
     "name": "Sunset Beach"
   },
   {
-    "hex": "#ffd6af ",
+    "hex": "#ffd6af",
     "label": "K-596",
     "name": "Melon Sorbet"
   },
   {
-    "hex": "#ffe3c6 ",
+    "hex": "#ffe3c6",
     "label": "K-597",
     "name": "Peach Rose"
   },
   {
-    "hex": "#fcead3 ",
+    "hex": "#fcead3",
     "label": "K-598",
     "name": "Simply Sunset"
   },
   {
-    "hex": "#f9f1e1 ",
+    "hex": "#f9f1e1",
     "label": "K-599",
     "name": "Villa Nor"
   },
   {
-    "hex": "#d26b33 ",
+    "hex": "#d26b33",
     "label": "K-600",
     "name": "Deep Spice"
   },
   {
-    "hex": "#eb905b ",
+    "hex": "#eb905b",
     "label": "K-601",
     "name": "Cimarron Trail"
   },
   {
-    "hex": "#f5a779 ",
+    "hex": "#f5a779",
     "label": "K-602",
     "name": "Moroccan Spice"
   },
   {
-    "hex": "#fabb93 ",
+    "hex": "#fabb93",
     "label": "K-603",
     "name": "Fawn Farrah"
   },
   {
-    "hex": "#ffd2b0 ",
+    "hex": "#ffd2b0",
     "label": "K-604",
     "name": "Dunhill"
   },
   {
-    "hex": "#fedcc1 ",
+    "hex": "#fedcc1",
     "label": "K-605",
     "name": "Bashful Beige"
   },
   {
-    "hex": "#fbead8 ",
+    "hex": "#fbead8",
     "label": "K-606",
     "name": "Pale Dawn"
   },
   {
-    "hex": "#f7f2e6 ",
+    "hex": "#f7f2e6",
     "label": "K-607",
     "name": "Thistle Down"
   },
   {
-    "hex": "#ae6241 ",
+    "hex": "#ae6241",
     "label": "K-608",
     "name": "Sunbaked Earth"
   },
   {
-    "hex": "#d07c50 ",
+    "hex": "#d07c50",
     "label": "K-609",
     "name": "Tuscan Terracotta"
   },
   {
-    "hex": "#e39d77 ",
+    "hex": "#e39d77",
     "label": "K-610",
     "name": "Beach Treasure"
   },
   {
-    "hex": "#f0b798 ",
+    "hex": "#f0b798",
     "label": "K-611",
     "name": "Sun-warmed Tile"
   },
   {
-    "hex": "#f6c9aa ",
+    "hex": "#f6c9aa",
     "label": "K-612",
     "name": "Orange Essence"
   },
   {
-    "hex": "#f9d4b8 ",
+    "hex": "#f9d4b8",
     "label": "K-613",
     "name": "Peach Beach"
   },
   {
-    "hex": "#f9dfc8 ",
+    "hex": "#f9dfc8",
     "label": "K-614",
     "name": "Toes in the Sand"
   },
   {
-    "hex": "#fae6d5 ",
+    "hex": "#fae6d5",
     "label": "K-615",
     "name": "Milk Shake"
   },
   {
-    "hex": "#af633e ",
+    "hex": "#af633e",
     "label": "K-616",
     "name": "Copper Moon"
   },
   {
-    "hex": "#bc734b ",
+    "hex": "#bc734b",
     "label": "K-617",
     "name": "Timeworn Terracotta"
   },
   {
-    "hex": "#d4916e ",
+    "hex": "#d4916e",
     "label": "K-618",
     "name": "Sunset Mesa"
   },
   {
-    "hex": "#e0a380 ",
+    "hex": "#e0a380",
     "label": "K-619",
     "name": "Coral Coast"
   },
   {
-    "hex": "#f2c19f ",
+    "hex": "#f2c19f",
     "label": "K-620",
     "name": "Salmon River"
   },
   {
-    "hex": "#f6d0b3 ",
+    "hex": "#f6d0b3",
     "label": "K-621",
     "name": "Australian Apricot"
   },
   {
-    "hex": "#f9e1cb ",
+    "hex": "#f9e1cb",
     "label": "K-622",
     "name": "Coral Cloud"
   },
   {
-    "hex": "#f7ecde ",
+    "hex": "#f7ecde",
     "label": "K-623",
     "name": "African Ivory"
   },
   {
-    "hex": "#ed6136 ",
+    "hex": "#ed6136",
     "label": "K-624",
     "name": "Hot Shot"
   },
   {
-    "hex": "#fa8658 ",
+    "hex": "#fa8658",
     "label": "K-625",
     "name": "Mathew's Fire"
   },
   {
-    "hex": "#fea17d ",
+    "hex": "#fea17d",
     "label": "K-626",
     "name": "Orange You Glad"
   },
   {
-    "hex": "#ffbb9d ",
+    "hex": "#ffbb9d",
     "label": "K-627",
     "name": "Orange Nectar"
   },
   {
-    "hex": "#ffcfb5 ",
+    "hex": "#ffcfb5",
     "label": "K-628",
     "name": "Mango Tango"
   },
   {
-    "hex": "#ffdec8 ",
+    "hex": "#ffdec8",
     "label": "K-629",
     "name": "Luminaria"
   },
   {
-    "hex": "#fde9d9 ",
+    "hex": "#fde9d9",
     "label": "K-630",
     "name": "Peach Cashmere"
   },
   {
-    "hex": "#f8eee2 ",
+    "hex": "#f8eee2",
     "label": "K-631",
     "name": "Peach Complexion"
   },
   {
-    "hex": "#be4e3d ",
+    "hex": "#be4e3d",
     "label": "K-632",
     "name": "Persimmon"
   },
   {
-    "hex": "#e17d63 ",
+    "hex": "#e17d63",
     "label": "K-633",
     "name": "Coral Cove"
   },
   {
-    "hex": "#f09d8a ",
+    "hex": "#f09d8a",
     "label": "K-634",
     "name": "Rosy Coral"
   },
   {
-    "hex": "#f8b5a4 ",
+    "hex": "#f8b5a4",
     "label": "K-635",
     "name": "Shade of Shell"
   },
   {
-    "hex": "#fec8b7 ",
+    "hex": "#fec8b7",
     "label": "K-636",
     "name": "Young Girl"
   },
   {
-    "hex": "#fed6c8 ",
+    "hex": "#fed6c8",
     "label": "K-637",
     "name": "Mussel Shell"
   },
   {
-    "hex": "#fde4d9 ",
+    "hex": "#fde4d9",
     "label": "K-638",
     "name": "Path of Petals"
   },
   {
-    "hex": "#fbeae1 ",
+    "hex": "#fbeae1",
     "label": "K-639",
     "name": "First Love"
   },
   {
-    "hex": "#e64e3a ",
+    "hex": "#e64e3a",
     "label": "K-640",
     "name": "Campfire Blaze"
   },
   {
-    "hex": "#f67c6c ",
+    "hex": "#f67c6c",
     "label": "K-641",
     "name": "Australian Coral"
   },
   {
-    "hex": "#fb988f ",
+    "hex": "#fb988f",
     "label": "K-642",
     "name": "Adonis Glow"
   },
   {
-    "hex": "#ffb2aa ",
+    "hex": "#ffb2aa",
     "label": "K-643",
     "name": "Perfect Touch"
   },
   {
-    "hex": "#ffccc4 ",
+    "hex": "#ffccc4",
     "label": "K-644",
     "name": "Deco Shell"
   },
   {
-    "hex": "#ffd8d0 ",
+    "hex": "#ffd8d0",
     "label": "K-645",
     "name": "Rose Hips"
   },
   {
-    "hex": "#fde3db ",
+    "hex": "#fde3db",
     "label": "K-646",
     "name": "Sherry Cream"
   },
   {
-    "hex": "#f9ede6 ",
+    "hex": "#f9ede6",
     "label": "K-647",
     "name": "Gossamer"
   },
   {
-    "hex": "#cb5345 ",
+    "hex": "#cb5345",
     "label": "K-648",
     "name": "Grand Duke"
   },
   {
-    "hex": "#e87f79 ",
+    "hex": "#e87f79",
     "label": "K-649",
     "name": "Fancy Nancy"
   },
   {
-    "hex": "#f29897 ",
+    "hex": "#f29897",
     "label": "K-650",
     "name": "Blossom Park"
   },
   {
-    "hex": "#fab4b2 ",
+    "hex": "#fab4b2",
     "label": "K-651",
     "name": "Her Majesty"
   },
   {
-    "hex": "#ffc9c7 ",
+    "hex": "#ffc9c7",
     "label": "K-652",
     "name": "Rose Point"
   },
   {
-    "hex": "#ffd1cd ",
+    "hex": "#ffd1cd",
     "label": "K-653",
     "name": "Bloomsbury"
   },
   {
-    "hex": "#fee1de ",
+    "hex": "#fee1de",
     "label": "K-654",
     "name": "Morningside"
   },
   {
-    "hex": "#faebe8 ",
+    "hex": "#faebe8",
     "label": "K-655",
     "name": "Devon Dawn"
   },
   {
-    "hex": "#df4338 ",
+    "hex": "#df4338",
     "label": "K-656",
     "name": "Salsa del Sol"
   },
   {
-    "hex": "#f37773 ",
+    "hex": "#f37773",
     "label": "K-657",
     "name": "Gabriel's Gift"
   },
   {
-    "hex": "#fa9594 ",
+    "hex": "#fa9594",
     "label": "K-658",
     "name": "Peaceful Princess"
   },
   {
-    "hex": "#ffaaaa ",
+    "hex": "#ffaaaa",
     "label": "K-659",
     "name": "Patient Pink"
   },
   {
-    "hex": "#ffc7c5 ",
+    "hex": "#ffc7c5",
     "label": "K-660",
     "name": "Spring Rose"
   },
   {
-    "hex": "#ffd8d5 ",
+    "hex": "#ffd8d5",
     "label": "K-661",
     "name": "Pink Perfection"
   },
   {
-    "hex": "#fde0dd ",
+    "hex": "#fde0dd",
     "label": "K-662",
     "name": "My Sweatheart"
   },
   {
-    "hex": "#f9eee9 ",
+    "hex": "#f9eee9",
     "label": "K-663",
     "name": "Willow Creek"
   },
   {
-    "hex": "#b34b42 ",
+    "hex": "#b34b42",
     "label": "K-664",
     "name": "Scarlet Sumac"
   },
   {
-    "hex": "#cd6766 ",
+    "hex": "#cd6766",
     "label": "K-665",
     "name": "May Fair"
   },
   {
-    "hex": "#dd8489 ",
+    "hex": "#dd8489",
     "label": "K-666",
     "name": "Sweet Amelia"
   },
   {
-    "hex": "#eea5a7 ",
+    "hex": "#eea5a7",
     "label": "K-667",
     "name": "Pink Carnation"
   },
   {
-    "hex": "#f8b8b9 ",
+    "hex": "#f8b8b9",
     "label": "K-668",
     "name": "Desert Bloom"
   },
   {
-    "hex": "#fcc3c6 ",
+    "hex": "#fcc3c6",
     "label": "K-669",
     "name": "Dulce Crystal"
   },
   {
-    "hex": "#fcd7d6 ",
+    "hex": "#fcd7d6",
     "label": "K-670",
     "name": "Pouf of Pink"
   },
   {
-    "hex": "#f9e9e6 ",
+    "hex": "#f9e9e6",
     "label": "K-671",
     "name": "Pale Perfection"
   },
   {
-    "hex": "#be2535 ",
+    "hex": "#be2535",
     "label": "K-672",
     "name": "Red Baron"
   },
   {
-    "hex": "#e06a78 ",
+    "hex": "#e06a78",
     "label": "K-673",
     "name": "Lady Love"
   },
   {
-    "hex": "#ef8d9d ",
+    "hex": "#ef8d9d",
     "label": "K-674",
     "name": "Wild Heather"
   },
   {
-    "hex": "#faaab6 ",
+    "hex": "#faaab6",
     "label": "K-675",
     "name": "Chelsea Rose"
   },
   {
-    "hex": "#fdbbc5 ",
+    "hex": "#fdbbc5",
     "label": "K-676",
     "name": "Ballet Slippers"
   },
   {
-    "hex": "#fecbd2 ",
+    "hex": "#fecbd2",
     "label": "K-677",
     "name": "Calique"
   },
   {
-    "hex": "#fedce1 ",
+    "hex": "#fedce1",
     "label": "K-678",
     "name": "Sweet Memories"
   },
   {
-    "hex": "#fce5e7 ",
+    "hex": "#fce5e7",
     "label": "K-679",
     "name": "Pink Mist"
   },
   {
-    "hex": "#cf252b ",
+    "hex": "#cf252b",
     "label": "K-680",
     "name": "Painter's Red"
   },
   {
-    "hex": "#f2728a ",
+    "hex": "#f2728a",
     "label": "K-681",
     "name": "P.J.'s"
   },
   {
-    "hex": "#f88fa7 ",
+    "hex": "#f88fa7",
     "label": "K-682",
     "name": "Pink Posey"
   },
   {
-    "hex": "#feafc2 ",
+    "hex": "#feafc2",
     "label": "K-683",
     "name": "Climbing Rose"
   },
   {
-    "hex": "#ffc2d0 ",
+    "hex": "#ffc2d0",
     "label": "K-684",
     "name": "Chenille Spread"
   },
   {
-    "hex": "#ffd6de ",
+    "hex": "#ffd6de",
     "label": "K-685",
     "name": "Fuzzy Slippers"
   },
   {
-    "hex": "#fce4e7 ",
+    "hex": "#fce4e7",
     "label": "K-686",
     "name": "Beth's Smile"
   },
   {
-    "hex": "#f9efed ",
+    "hex": "#f9efed",
     "label": "K-687",
     "name": "Winged Angel"
   },
   {
-    "hex": "#7f3e42 ",
+    "hex": "#7f3e42",
     "label": "K-688",
     "name": "Prado Red"
   },
   {
-    "hex": "#a76567 ",
+    "hex": "#a76567",
     "label": "K-689",
     "name": "Rose Queen"
   },
   {
-    "hex": "#b47477 ",
+    "hex": "#b47477",
     "label": "K-690",
     "name": "Mauve Medley"
   },
   {
-    "hex": "#ca9499 ",
+    "hex": "#ca9499",
     "label": "K-691",
     "name": "Vintage Rose"
   },
   {
-    "hex": "#daabb1 ",
+    "hex": "#daabb1",
     "label": "K-692",
     "name": "Spring Cheer"
   },
   {
-    "hex": "#eac0c3 ",
+    "hex": "#eac0c3",
     "label": "K-693",
     "name": "Minute Mauve"
   },
   {
-    "hex": "#f3d7d8 ",
+    "hex": "#f3d7d8",
     "label": "K-694",
     "name": "Berry Good"
   },
   {
-    "hex": "#f5e7e4 ",
+    "hex": "#f5e7e4",
     "label": "K-695",
     "name": "Pale Petals"
   },
   {
-    "hex": "#813545 ",
+    "hex": "#813545",
     "label": "K-696",
     "name": "Fine Wine "
   },
   {
-    "hex": "#b66972 ",
+    "hex": "#b66972",
     "label": "K-697",
     "name": "Wild Berry"
   },
   {
-    "hex": "#c87f87 ",
+    "hex": "#c87f87",
     "label": "K-698",
     "name": "Melita"
   },
   {
-    "hex": "#d28e9a ",
+    "hex": "#d28e9a",
     "label": "K-699",
     "name": "Wild Scottish Rose"
   },
   {
-    "hex": "#e6aeb6 ",
+    "hex": "#e6aeb6",
     "label": "K-700",
     "name": "Sweet Heart"
   },
   {
-    "hex": "#f2c6cb ",
+    "hex": "#f2c6cb",
     "label": "K-701",
     "name": "Briar Rose"
   },
   {
-    "hex": "#f8dcde ",
+    "hex": "#f8dcde",
     "label": "K-702",
     "name": "Primrose Cottage"
   },
   {
-    "hex": "#f8ecea ",
+    "hex": "#f8ecea",
     "label": "K-703",
     "name": "Blush of Spring"
   },
   {
-    "hex": "#a0293d ",
+    "hex": "#a0293d",
     "label": "K-704",
     "name": "Jay's New Toy"
   },
   {
-    "hex": "#be5e6b ",
+    "hex": "#be5e6b",
     "label": "K-705",
     "name": "Lipstick Pink"
   },
   {
-    "hex": "#da8c9b ",
+    "hex": "#da8c9b",
     "label": "K-706",
     "name": "Rosey Bouquet"
   },
   {
-    "hex": "#e4a0ae ",
+    "hex": "#e4a0ae",
     "label": "K-707",
     "name": "Susan's Smile"
   },
   {
-    "hex": "#f1b7c3 ",
+    "hex": "#f1b7c3",
     "label": "K-708",
     "name": "Party Pink"
   },
   {
-    "hex": "#f5c6cf ",
+    "hex": "#f5c6cf",
     "label": "K-709",
     "name": "Blossom Beauty"
   },
   {
-    "hex": "#f7d5da ",
+    "hex": "#f7d5da",
     "label": "K-710",
     "name": "Go Girl!"
   },
   {
-    "hex": "#f7e0e3 ",
+    "hex": "#f7e0e3",
     "label": "K-711",
     "name": "Sweet Illusions"
   },
   {
-    "hex": "#9f253d ",
+    "hex": "#9f253d",
     "label": "K-712",
     "name": "Francesca"
   },
   {
-    "hex": "#e06793 ",
+    "hex": "#e06793",
     "label": "K-713",
     "name": "Rich Desires"
   },
   {
-    "hex": "#ed8db5 ",
+    "hex": "#ed8db5",
     "label": "K-714",
     "name": "Karen's Kiss"
   },
   {
-    "hex": "#f5afcb ",
+    "hex": "#f5afcb",
     "label": "K-715",
     "name": "Budding Rose"
   },
   {
-    "hex": "#f9bfd7 ",
+    "hex": "#f9bfd7",
     "label": "K-716",
     "name": "Josie's Joy"
   },
   {
-    "hex": "#fad3e2 ",
+    "hex": "#fad3e2",
     "label": "K-717",
     "name": "Rose Rhapsody"
   },
   {
-    "hex": "#fbdee7 ",
+    "hex": "#fbdee7",
     "label": "K-718",
     "name": "First Dawn"
   },
   {
-    "hex": "#f9ebed ",
+    "hex": "#f9ebed",
     "label": "K-719",
     "name": "Pale Blush"
   },
   {
-    "hex": "#932944 ",
+    "hex": "#932944",
     "label": "K-720",
     "name": "It's the Berries"
   },
   {
-    "hex": "#bb6b8c ",
+    "hex": "#bb6b8c",
     "label": "K-721",
     "name": "Raisa"
   },
   {
-    "hex": "#d993b1 ",
+    "hex": "#d993b1",
     "label": "K-722",
     "name": "Euphoric Rose"
   },
   {
-    "hex": "#e3aec5 ",
+    "hex": "#e3aec5",
     "label": "K-723",
     "name": "Baby Yourself"
   },
   {
-    "hex": "#f5c0d3 ",
+    "hex": "#f5c0d3",
     "label": "K-724",
     "name": "Rose Camilla"
   },
   {
-    "hex": "#f7d1de ",
+    "hex": "#f7d1de",
     "label": "K-725",
     "name": "Baby Blush"
   },
   {
-    "hex": "#f8dee6 ",
+    "hex": "#f8dee6",
     "label": "K-726",
     "name": "Sweet Roses"
   },
   {
-    "hex": "#f9eeee ",
+    "hex": "#f9eeee",
     "label": "K-727",
     "name": "Pink Ice"
   },
   {
-    "hex": "#863a5e ",
+    "hex": "#863a5e",
     "label": "K-728",
     "name": "Fine Burgundy"
   },
   {
-    "hex": "#b97093 ",
+    "hex": "#b97093",
     "label": "K-729",
     "name": "The Marquis"
   },
   {
-    "hex": "#c582a3 ",
+    "hex": "#c582a3",
     "label": "K-730",
     "name": "Santa Rosa"
   },
   {
-    "hex": "#ddaac5 ",
+    "hex": "#ddaac5",
     "label": "K-731",
     "name": "Heirloom Rose"
   },
   {
-    "hex": "#edc2d7 ",
+    "hex": "#edc2d7",
     "label": "K-732",
     "name": "Roses in the Snow"
   },
   {
-    "hex": "#f1d0de ",
+    "hex": "#f1d0de",
     "label": "K-733",
     "name": "Smidgen of Cloud"
   },
   {
-    "hex": "#f5dee6 ",
+    "hex": "#f5dee6",
     "label": "K-734",
     "name": "Sheridan"
   },
   {
-    "hex": "#f7e8ec ",
+    "hex": "#f7e8ec",
     "label": "K-735",
     "name": "Prettiest Pale"
   },
   {
-    "hex": "#6b3450 ",
+    "hex": "#6b3450",
     "label": "K-736",
     "name": "Country Cranberry"
   },
   {
-    "hex": "#b66da4 ",
+    "hex": "#b66da4",
     "label": "K-737",
     "name": "Earth Fired Red"
   },
   {
-    "hex": "#ce94c3 ",
+    "hex": "#ce94c3",
     "label": "K-738",
     "name": "Autumn Sedum"
   },
   {
-    "hex": "#dba8d1 ",
+    "hex": "#dba8d1",
     "label": "K-739",
     "name": "French Rose"
   },
   {
-    "hex": "#ebbfdf ",
+    "hex": "#ebbfdf",
     "label": "K-740",
     "name": "Rosarian"
   },
   {
-    "hex": "#efc9e3 ",
+    "hex": "#efc9e3",
     "label": "K-741",
     "name": "Cabbage Rose"
   },
   {
-    "hex": "#f4d9eb ",
+    "hex": "#f4d9eb",
     "label": "K-742",
     "name": "Spring Petals"
   },
   {
-    "hex": "#f4e3ec ",
+    "hex": "#f4e3ec",
     "label": "K-743",
     "name": "Rosy View"
   },
   {
-    "hex": "#513249 ",
+    "hex": "#513249",
     "label": "K-744",
     "name": "So Merlot"
   },
   {
-    "hex": "#87657a ",
+    "hex": "#87657a",
     "label": "K-745",
     "name": "Orchard Plum"
   },
   {
-    "hex": "#92778a ",
+    "hex": "#92778a",
     "label": "K-746",
     "name": "Beguiling Blossom"
   },
   {
-    "hex": "#a48b9f ",
+    "hex": "#a48b9f",
     "label": "K-747",
     "name": "Lady Like"
   },
   {
-    "hex": "#c1acbb ",
+    "hex": "#c1acbb",
     "label": "K-748",
     "name": "Light Rosa"
   },
   {
-    "hex": "#d7bfcb ",
+    "hex": "#d7bfcb",
     "label": "K-749",
     "name": "Pink Peace"
   },
   {
-    "hex": "#ead9de ",
+    "hex": "#ead9de",
     "label": "K-750",
     "name": "Sweet and Sassy"
   },
   {
-    "hex": "#f4edec ",
+    "hex": "#f4edec",
     "label": "K-751",
     "name": "Daybreak Mood"
   },
   {
-    "hex": "#513b4b ",
+    "hex": "#513b4b",
     "label": "K-752",
     "name": "Autumn Plum"
   },
   {
-    "hex": "#7f6e78 ",
+    "hex": "#7f6e78",
     "label": "K-753",
     "name": "Lady Carlyle"
   },
   {
-    "hex": "#94838d ",
+    "hex": "#94838d",
     "label": "K-754",
     "name": "Rosabella"
   },
   {
-    "hex": "#a495a1 ",
+    "hex": "#a495a1",
     "label": "K-755",
     "name": "Lida Rose"
   },
   {
-    "hex": "#c1b4bd ",
+    "hex": "#c1b4bd",
     "label": "K-756",
     "name": "Apple Blossom Time"
   },
   {
-    "hex": "#d6c7cc ",
+    "hex": "#d6c7cc",
     "label": "K-757",
     "name": "Pretty Princess"
   },
   {
-    "hex": "#e8ddde ",
+    "hex": "#e8ddde",
     "label": "K-758",
     "name": "Placid Pink"
   },
   {
-    "hex": "#eee7e6 ",
+    "hex": "#eee7e6",
     "label": "K-759",
     "name": "Magical Mourn"
   },
   {
-    "hex": "#3f343a ",
+    "hex": "#3f343a",
     "label": "K-760",
     "name": "Dark Berry"
   },
   {
-    "hex": "#7b6e73 ",
+    "hex": "#7b6e73",
     "label": "K-761",
     "name": "Plum Island"
   },
   {
-    "hex": "#93878b ",
+    "hex": "#93878b",
     "label": "K-762",
     "name": "Lavender Rose"
   },
   {
-    "hex": "#aea4a9 ",
+    "hex": "#aea4a9",
     "label": "K-763",
     "name": "Heather Ridge"
   },
   {
-    "hex": "#beb5b9 ",
+    "hex": "#beb5b9",
     "label": "K-764",
     "name": "Romantic Light"
   },
   {
-    "hex": "#d3c8c9 ",
+    "hex": "#d3c8c9",
     "label": "K-765",
     "name": "Easter Egg"
   },
   {
-    "hex": "#e0d7d7 ",
+    "hex": "#e0d7d7",
     "label": "K-766",
     "name": "Plum Proud"
   },
   {
-    "hex": "#ece6e3 ",
+    "hex": "#ece6e3",
     "label": "K-767",
     "name": "Grape Expectations"
   },
   {
-    "hex": "#433c3c ",
+    "hex": "#433c3c",
     "label": "K-768",
     "name": "Evening Empress"
   },
   {
-    "hex": "#5d585b ",
+    "hex": "#5d585b",
     "label": "K-769",
     "name": "Zuli"
   },
   {
-    "hex": "#6f6b6f ",
+    "hex": "#6f6b6f",
     "label": "K-770",
     "name": "Last Light"
   },
   {
-    "hex": "#87868b ",
+    "hex": "#87868b",
     "label": "K-771",
     "name": "Girgitta"
   },
   {
-    "hex": "#a3a1a5 ",
+    "hex": "#a3a1a5",
     "label": "K-772",
     "name": "Heather Harmony"
   },
   {
-    "hex": "#bbb7b8 ",
+    "hex": "#bbb7b8",
     "label": "K-773",
     "name": "Pashmina"
   },
   {
-    "hex": "#d9d7d6 ",
+    "hex": "#d9d7d6",
     "label": "K-774",
     "name": "Sweet Musette"
   },
   {
-    "hex": "#eae8e5 ",
+    "hex": "#eae8e5",
     "label": "K-775",
     "name": "Iced Silver"
   },
   {
-    "hex": "#36373c ",
+    "hex": "#36373c",
     "label": "K-776",
     "name": "In the Dark"
   },
   {
-    "hex": "#5a5c64 ",
+    "hex": "#5a5c64",
     "label": "K-777",
     "name": "Five O'Clock Shadow"
   },
   {
-    "hex": "#6d7079 ",
+    "hex": "#6d7079",
     "label": "K-778",
     "name": "Gray Whale Cove"
   },
   {
-    "hex": "#7f848e ",
+    "hex": "#7f848e",
     "label": "K-779",
     "name": "Shadow Mountain"
   },
   {
-    "hex": "#a3a7af ",
+    "hex": "#a3a7af",
     "label": "K-780",
     "name": "Bethel Corner"
   },
   {
-    "hex": "#bbbbc0 ",
+    "hex": "#bbbbc0",
     "label": "K-781",
     "name": "October Sky"
   },
   {
-    "hex": "#d4d4d5 ",
+    "hex": "#d4d4d5",
     "label": "K-782",
     "name": "White Palace"
   },
   {
-    "hex": "#dfdedf ",
+    "hex": "#dfdedf",
     "label": "K-783",
     "name": "Billowing Clouds"
   },
   {
-    "hex": "#282728 ",
+    "hex": "#282728",
     "label": "K-784",
     "name": "Kitty Kitty"
   },
   {
-    "hex": "#575d65 ",
+    "hex": "#575d65",
     "label": "K-785",
     "name": "Smokey Hearth"
   },
   {
-    "hex": "#6b727a ",
+    "hex": "#6b727a",
     "label": "K-786",
     "name": "Made in the Shade"
   },
   {
-    "hex": "#959da5 ",
+    "hex": "#959da5",
     "label": "K-787",
     "name": "Madison Grey"
   },
   {
-    "hex": "#aeb3b8 ",
+    "hex": "#aeb3b8",
     "label": "K-788",
     "name": "Dolphin Dance"
   },
   {
-    "hex": "#caced0 ",
+    "hex": "#caced0",
     "label": "K-789",
     "name": "Where there is Smoke"
   },
   {
-    "hex": "#e3e5e4 ",
+    "hex": "#e3e5e4",
     "label": "K-790",
     "name": "Heirloom Silver"
   },
   {
-    "hex": "#f0f0eb ",
+    "hex": "#f0f0eb",
     "label": "K-791",
     "name": "Mercury"
   },
   {
-    "hex": "#49484c ",
+    "hex": "#49484c",
     "label": "K-792",
     "name": "New Uniform"
   },
   {
-    "hex": "#57626b ",
+    "hex": "#57626b",
     "label": "K-793",
     "name": "Blue Lake"
   },
   {
-    "hex": "#646f79 ",
+    "hex": "#646f79",
     "label": "K-794",
     "name": "Romantic Mood"
   },
   {
-    "hex": "#748490 ",
+    "hex": "#748490",
     "label": "K-795",
     "name": "Mirador"
   },
   {
-    "hex": "#8e9ca6 ",
+    "hex": "#8e9ca6",
     "label": "K-796",
     "name": "Brookview"
   },
   {
-    "hex": "#a1b4bf ",
+    "hex": "#a1b4bf",
     "label": "K-797",
     "name": "Bali Blue"
   },
   {
-    "hex": "#c2cdd2 ",
+    "hex": "#c2cdd2",
     "label": "K-798",
     "name": "Quiet Sentiment"
   },
   {
-    "hex": "#d9dee0 ",
+    "hex": "#d9dee0",
     "label": "K-799",
     "name": "Moonlight Blue"
   },
   {
-    "hex": "#313b45 ",
+    "hex": "#313b45",
     "label": "K-800",
     "name": "In the Navy"
   },
   {
-    "hex": "#495d6b ",
+    "hex": "#495d6b",
     "label": "K-801",
     "name": "Blazing Sky"
   },
   {
-    "hex": "#6e8393 ",
+    "hex": "#6e8393",
     "label": "K-802",
     "name": "Tucker's Toy"
   },
   {
-    "hex": "#8da2b0 ",
+    "hex": "#8da2b0",
     "label": "K-803",
     "name": "Blue Horizon"
   },
   {
-    "hex": "#9fb4c1 ",
+    "hex": "#9fb4c1",
     "label": "K-804",
     "name": "Grand Bay"
   },
   {
-    "hex": "#b6c7d0 ",
+    "hex": "#b6c7d0",
     "label": "K-805",
     "name": "Sky's the Limit"
   },
   {
-    "hex": "#d0dade ",
+    "hex": "#d0dade",
     "label": "K-806",
     "name": "Clear to See"
   },
   {
-    "hex": "#e3e8e8 ",
+    "hex": "#e3e8e8",
     "label": "K-807",
     "name": "Snippet of Blue"
   },
   {
-    "hex": "#383a39 ",
+    "hex": "#383a39",
     "label": "K-808",
     "name": "Contessa's Cape"
   },
   {
-    "hex": "#565b5d ",
+    "hex": "#565b5d",
     "label": "K-809",
     "name": "Charcoal Shadow"
   },
   {
-    "hex": "#63686a ",
+    "hex": "#63686a",
     "label": "K-810",
     "name": "Grafton Grey"
   },
   {
-    "hex": "#81878a ",
+    "hex": "#81878a",
     "label": "K-811",
     "name": "Stone Age"
   },
   {
-    "hex": "#9ea4a6 ",
+    "hex": "#9ea4a6",
     "label": "K-812",
     "name": "Cold Steel"
   },
   {
-    "hex": "#babdbc ",
+    "hex": "#babdbc",
     "label": "K-813",
     "name": "Prairie Smoke"
   },
   {
-    "hex": "#d0d3d1 ",
+    "hex": "#d0d3d1",
     "label": "K-814",
     "name": "Grey Mare"
   },
   {
-    "hex": "#e7e7e3 ",
+    "hex": "#e7e7e3",
     "label": "K-815",
     "name": "Quick Silver"
   },
   {
-    "hex": "#3c3731 ",
+    "hex": "#3c3731",
     "label": "K-816",
     "name": "Carbon Copy"
   },
   {
-    "hex": "#5f5d5a ",
+    "hex": "#5f5d5a",
     "label": "K-817",
     "name": "Dark Shadows"
   },
   {
-    "hex": "#858483 ",
+    "hex": "#858483",
     "label": "K-818",
     "name": "Cast in Stone"
   },
   {
-    "hex": "#a1a1a0 ",
+    "hex": "#a1a1a0",
     "label": "K-819",
     "name": "Diamond Heights"
   },
   {
-    "hex": "#b8b7b2 ",
+    "hex": "#b8b7b2",
     "label": "K-820",
     "name": "Platinum Plate"
   },
   {
-    "hex": "#cac8c4 ",
+    "hex": "#cac8c4",
     "label": "K-821",
     "name": "Silver Queen"
   },
   {
-    "hex": "#d8d6d1 ",
+    "hex": "#d8d6d1",
     "label": "K-822",
     "name": "Ice Age"
   },
   {
-    "hex": "#e4e2dd ",
+    "hex": "#e4e2dd",
     "label": "K-823",
     "name": "Snowflake Confetti"
   },
   {
-    "hex": "#42423e ",
+    "hex": "#42423e",
     "label": "K-824",
     "name": "Opening Night"
   },
   {
-    "hex": "#5e5f5d ",
+    "hex": "#5e5f5d",
     "label": "K-825",
     "name": "Great Graphite"
   },
   {
-    "hex": "#6e6f6d ",
+    "hex": "#6e6f6d",
     "label": "K-826",
     "name": "Shadow Dance"
   },
   {
-    "hex": "#838584 ",
+    "hex": "#838584",
     "label": "K-827",
     "name": "Grey Matters"
   },
   {
-    "hex": "#a1a4a3 ",
+    "hex": "#a1a4a3",
     "label": "K-828",
     "name": "Titanic Grey"
   },
   {
-    "hex": "#bbbab6 ",
+    "hex": "#bbbab6",
     "label": "K-829",
     "name": "Zephyr"
   },
   {
-    "hex": "#cbcbc7 ",
+    "hex": "#cbcbc7",
     "label": "K-830",
     "name": "Fading Fog"
   },
   {
-    "hex": "#d8d8d4 ",
+    "hex": "#d8d8d4",
     "label": "K-831",
     "name": "Whispering Smoke"
   },
   {
-    "hex": "#3f4341 ",
+    "hex": "#3f4341",
     "label": "K-832",
     "name": "Midnight in the Tropics"
   },
   {
-    "hex": "#58615f ",
+    "hex": "#58615f",
     "label": "K-833",
     "name": "Shady Place"
   },
   {
-    "hex": "#6a7271 ",
+    "hex": "#6a7271",
     "label": "K-834",
     "name": "Roman Stone"
   },
   {
-    "hex": "#7e8788 ",
+    "hex": "#7e8788",
     "label": "K-835",
     "name": "Gothic Grey"
   },
   {
-    "hex": "#9aa3a3 ",
+    "hex": "#9aa3a3",
     "label": "K-836",
     "name": "Raw Steel"
   },
   {
-    "hex": "#b2b9b6 ",
+    "hex": "#b2b9b6",
     "label": "K-837",
     "name": "Wintry Sky"
   },
   {
-    "hex": "#bfc5c0 ",
+    "hex": "#bfc5c0",
     "label": "K-838",
     "name": "Grey Mist"
   },
   {
-    "hex": "#dbded9 ",
+    "hex": "#dbded9",
     "label": "K-839",
     "name": "First Frost"
   },
   {
-    "hex": "#4a4b44 ",
+    "hex": "#4a4b44",
     "label": "K-840",
     "name": "Dark Moon"
   },
   {
-    "hex": "#60635b ",
+    "hex": "#60635b",
     "label": "K-841",
     "name": "Castlemare"
   },
   {
-    "hex": "#6f726a ",
+    "hex": "#6f726a",
     "label": "K-842",
     "name": "Burnished Pewter"
   },
   {
-    "hex": "#848882 ",
+    "hex": "#848882",
     "label": "K-843",
     "name": "Slippery Shale"
   },
   {
-    "hex": "#9b9f99 ",
+    "hex": "#9b9f99",
     "label": "K-844",
     "name": "Pussy Willow"
   },
   {
-    "hex": "#b9bab1 ",
+    "hex": "#b9bab1",
     "label": "K-845",
     "name": "Hi Ho Silver"
   },
   {
-    "hex": "#c6c7be ",
+    "hex": "#c6c7be",
     "label": "K-846",
     "name": "Winter Way"
   },
   {
-    "hex": "#dcdcd4 ",
+    "hex": "#dcdcd4",
     "label": "K-847",
     "name": "Siberian Snowflake"
   },
   {
-    "hex": "#3a4040 ",
+    "hex": "#3a4040",
     "label": "K-848",
     "name": "Moonless Sky"
   },
   {
-    "hex": "#5d6b6b ",
+    "hex": "#5d6b6b",
     "label": "K-849",
     "name": "Wrapped in Twilight"
   },
   {
-    "hex": "#6f7c7c ",
+    "hex": "#6f7c7c",
     "label": "K-850",
     "name": "Rio Bravo"
   },
   {
-    "hex": "#859495 ",
+    "hex": "#859495",
     "label": "K-851",
     "name": "Pools of Blue"
   },
   {
-    "hex": "#a0adad ",
+    "hex": "#a0adad",
     "label": "K-852",
     "name": "Waterby"
   },
   {
-    "hex": "#bcc7c3 ",
+    "hex": "#bcc7c3",
     "label": "K-853",
     "name": "Quiet Cove"
   },
   {
-    "hex": "#c7d1cd ",
+    "hex": "#c7d1cd",
     "label": "K-854",
     "name": "Dancing Bubbles"
   },
   {
-    "hex": "#d7ddd9 ",
+    "hex": "#d7ddd9",
     "label": "K-855",
     "name": "Whispering Waterfall"
   },
   {
-    "hex": "#294344 ",
+    "hex": "#294344",
     "label": "K-856",
     "name": "Cape Royal"
   },
   {
-    "hex": "#5a716d ",
+    "hex": "#5a716d",
     "label": "K-857",
     "name": "Under Water World"
   },
   {
-    "hex": "#7f9796 ",
+    "hex": "#7f9796",
     "label": "K-858",
     "name": "Forest Falls"
   },
   {
-    "hex": "#9fb4b2 ",
+    "hex": "#9fb4b2",
     "label": "K-859",
     "name": "Mystic Lake"
   },
   {
-    "hex": "#b1c6c1 ",
+    "hex": "#b1c6c1",
     "label": "K-860",
     "name": "Sea Dreams"
   },
   {
-    "hex": "#c4d6d0 ",
+    "hex": "#c4d6d0",
     "label": "K-861",
     "name": "Misty Harbor"
   },
   {
-    "hex": "#dce5e0 ",
+    "hex": "#dce5e0",
     "label": "K-862",
     "name": "Ocean Cliffs"
   },
   {
-    "hex": "#e8ece6 ",
+    "hex": "#e8ece6",
     "label": "K-863",
     "name": "Water Spirit"
   },
   {
-    "hex": "#495146 ",
+    "hex": "#495146",
     "label": "K-864",
     "name": "Opera Evening"
   },
   {
-    "hex": "#626f63 ",
+    "hex": "#626f63",
     "label": "K-865",
     "name": "Logan Lake"
   },
   {
-    "hex": "#768477 ",
+    "hex": "#768477",
     "label": "K-866",
     "name": "Green Shadow"
   },
   {
-    "hex": "#89978d ",
+    "hex": "#89978d",
     "label": "K-867",
     "name": "River Rhythm"
   },
   {
-    "hex": "#a0ada3 ",
+    "hex": "#a0ada3",
     "label": "K-868",
     "name": "Artful Green"
   },
   {
-    "hex": "#bdc8bc ",
+    "hex": "#bdc8bc",
     "label": "K-869",
     "name": "Rain Mist"
   },
   {
-    "hex": "#d7ded4 ",
+    "hex": "#d7ded4",
     "label": "K-870",
     "name": "London Fog"
   },
   {
-    "hex": "#ebede5 ",
+    "hex": "#ebede5",
     "label": "K-871",
     "name": "Spirit Wind"
   },
   {
-    "hex": "#515f44 ",
+    "hex": "#515f44",
     "label": "K-872",
     "name": "Glade Creek"
   },
   {
-    "hex": "#6c8064 ",
+    "hex": "#6c8064",
     "label": "K-873",
     "name": "Spruce Spring"
   },
   {
-    "hex": "#7b8e71 ",
+    "hex": "#7b8e71",
     "label": "K-874",
     "name": "Maine Mist"
   },
   {
-    "hex": "#92a58d ",
+    "hex": "#92a58d",
     "label": "K-875",
     "name": "Green Silence"
   },
   {
-    "hex": "#a7b9a2 ",
+    "hex": "#a7b9a2",
     "label": "K-876",
     "name": "When Twilight Falls"
   },
   {
-    "hex": "#b9cbb4 ",
+    "hex": "#b9cbb4",
     "label": "K-877",
     "name": "Eucalyptus Leaf"
   },
   {
-    "hex": "#d1decc ",
+    "hex": "#d1decc",
     "label": "K-878",
     "name": "Tudor Grove"
   },
   {
-    "hex": "#e7ece0 ",
+    "hex": "#e7ece0",
     "label": "K-879",
     "name": "Spinney Mountain"
   },
   {
-    "hex": "#505646 ",
+    "hex": "#505646",
     "label": "K-880",
     "name": "Irish Moss"
   },
   {
-    "hex": "#687060 ",
+    "hex": "#687060",
     "label": "K-881",
     "name": "Glen Ivy"
   },
   {
-    "hex": "#777f6e ",
+    "hex": "#777f6e",
     "label": "K-882",
     "name": "Valley Vista"
   },
   {
-    "hex": "#858f80 ",
+    "hex": "#858f80",
     "label": "K-883",
     "name": "Majestic Evergreen"
   },
   {
-    "hex": "#a2ab9d ",
+    "hex": "#a2ab9d",
     "label": "K-884",
     "name": "Hidden Ravine"
   },
   {
-    "hex": "#bcc4b5 ",
+    "hex": "#bcc4b5",
     "label": "K-885",
     "name": "Gardening Trend"
   },
   {
-    "hex": "#d0d6c8 ",
+    "hex": "#d0d6c8",
     "label": "K-886",
     "name": "Wild Grass"
   },
   {
-    "hex": "#dee2d6 ",
+    "hex": "#dee2d6",
     "label": "K-887",
     "name": "Ridgefield"
   },
   {
-    "hex": "#585c49 ",
+    "hex": "#585c49",
     "label": "K-888",
     "name": "Clearfield"
   },
   {
-    "hex": "#6c715e ",
+    "hex": "#6c715e",
     "label": "K-889",
     "name": "Spring's Eve"
   },
   {
-    "hex": "#8c9280 ",
+    "hex": "#8c9280",
     "label": "K-890",
     "name": "Maid of the Mist"
   },
   {
-    "hex": "#969c8a ",
+    "hex": "#969c8a",
     "label": "K-891",
     "name": "Pineview"
   },
   {
-    "hex": "#abb09e ",
+    "hex": "#abb09e",
     "label": "K-892",
     "name": "Song of Nature"
   },
   {
-    "hex": "#c1c5b1 ",
+    "hex": "#c1c5b1",
     "label": "K-893",
     "name": "Fernwood"
   },
   {
-    "hex": "#cfd2c1 ",
+    "hex": "#cfd2c1",
     "label": "K-894",
     "name": "Vintage Find"
   },
   {
-    "hex": "#e6e7da ",
+    "hex": "#e6e7da",
     "label": "K-895",
     "name": "Sage Tinged"
   },
   {
-    "hex": "#5a6045 ",
+    "hex": "#5a6045",
     "label": "K-896",
     "name": "Ladies' Night"
   },
   {
-    "hex": "#747d62 ",
+    "hex": "#747d62",
     "label": "K-897",
     "name": "Green Dusk"
   },
   {
-    "hex": "#878f73 ",
+    "hex": "#878f73",
     "label": "K-898",
     "name": "Port Alice"
   },
   {
-    "hex": "#9ea78f ",
+    "hex": "#9ea78f",
     "label": "K-899",
     "name": "Woodland Waterfall"
   },
   {
-    "hex": "#b0b8a2 ",
+    "hex": "#b0b8a2",
     "label": "K-900",
     "name": "Dream Weaver"
   },
   {
-    "hex": "#c4ccb3 ",
+    "hex": "#c4ccb3",
     "label": "K-901",
     "name": "Water Magic"
   },
   {
-    "hex": "#dbe0ce ",
+    "hex": "#dbe0ce",
     "label": "K-902",
     "name": "Mystical Mist"
   },
   {
-    "hex": "#edeee2 ",
+    "hex": "#edeee2",
     "label": "K-903",
     "name": "Glacier Valley"
   },
   {
-    "hex": "#616b49 ",
+    "hex": "#616b49",
     "label": "K-904",
     "name": "Evergreen Trail"
   },
   {
-    "hex": "#71805e ",
+    "hex": "#71805e",
     "label": "K-905",
     "name": "Old Growth Forest"
   },
   {
-    "hex": "#808e6b ",
+    "hex": "#808e6b",
     "label": "K-906",
     "name": "Buchanan Gardens"
   },
   {
-    "hex": "#8f9d80 ",
+    "hex": "#8f9d80",
     "label": "K-907",
     "name": "Silver Mound"
   },
   {
-    "hex": "#adb99e ",
+    "hex": "#adb99e",
     "label": "K-908",
     "name": "Lamb's Ear"
   },
   {
-    "hex": "#c4d0b5 ",
+    "hex": "#c4d0b5",
     "label": "K-909",
     "name": "Foresta"
   },
   {
-    "hex": "#d0dac2 ",
+    "hex": "#d0dac2",
     "label": "K-910",
     "name": "Fraser Lake"
   },
   {
-    "hex": "#dfe5d3 ",
+    "hex": "#dfe5d3",
     "label": "K-911",
     "name": "Hyde Park"
   },
   {
-    "hex": "#595847 ",
+    "hex": "#595847",
     "label": "K-912",
     "name": "Fortune Leaves"
   },
   {
-    "hex": "#6c6b5a ",
+    "hex": "#6c6b5a",
     "label": "K-913",
     "name": "Hampstead"
   },
   {
-    "hex": "#8b8c7d ",
+    "hex": "#8b8c7d",
     "label": "K-914",
     "name": "French Clay"
   },
   {
-    "hex": "#989889 ",
+    "hex": "#989889",
     "label": "K-915",
     "name": "Rock Wall"
   },
   {
-    "hex": "#abac9d ",
+    "hex": "#abac9d",
     "label": "K-916",
     "name": "Marble Quarry"
   },
   {
-    "hex": "#c4c2b1 ",
+    "hex": "#c4c2b1",
     "label": "K-917",
     "name": "Dillard"
   },
   {
-    "hex": "#dad8ca ",
+    "hex": "#dad8ca",
     "label": "K-918",
     "name": "Wishing Star"
   },
   {
-    "hex": "#ebe9df ",
+    "hex": "#ebe9df",
     "label": "K-919",
     "name": "Glacier Ridge"
   },
   {
-    "hex": "#4b4639 ",
+    "hex": "#4b4639",
     "label": "K-920",
     "name": "Bravo Brown"
   },
   {
-    "hex": "#6f6a5d ",
+    "hex": "#6f6a5d",
     "label": "K-921",
     "name": "Rock of Ages"
   },
   {
-    "hex": "#787466 ",
+    "hex": "#787466",
     "label": "K-922",
     "name": "Rolling Stone"
   },
   {
-    "hex": "#8b897e ",
+    "hex": "#8b897e",
     "label": "K-923",
     "name": "Garden Bench"
   },
   {
-    "hex": "#a9a79d ",
+    "hex": "#a9a79d",
     "label": "K-924",
     "name": "Ashford"
   },
   {
-    "hex": "#c2bdb0 ",
+    "hex": "#c2bdb0",
     "label": "K-925",
     "name": "Silver Spree"
   },
   {
-    "hex": "#d8d4ca ",
+    "hex": "#d8d4ca",
     "label": "K-926",
     "name": "Pewter Moon"
   },
   {
-    "hex": "#ebe8e0 ",
+    "hex": "#ebe8e0",
     "label": "K-927",
     "name": "White Delight"
   },
   {
-    "hex": "#5c5242 ",
+    "hex": "#5c5242",
     "label": "K-928",
     "name": "Pilot Rock"
   },
   {
-    "hex": "#6f675c ",
+    "hex": "#6f675c",
     "label": "K-929",
     "name": "Castle Dale"
   },
   {
-    "hex": "#837b6f ",
+    "hex": "#837b6f",
     "label": "K-930",
     "name": "Hidcote Manor"
   },
   {
-    "hex": "#948e85 ",
+    "hex": "#948e85",
     "label": "K-931",
     "name": "Granite Cliff"
   },
   {
-    "hex": "#b2a99e ",
+    "hex": "#b2a99e",
     "label": "K-932",
     "name": "Zanzibar"
   },
   {
-    "hex": "#d5cdc0 ",
+    "hex": "#d5cdc0",
     "label": "K-933",
     "name": "Weathered White"
   },
   {
-    "hex": "#dfd9ce ",
+    "hex": "#dfd9ce",
     "label": "K-934",
     "name": "Silver Plume"
   },
   {
-    "hex": "#f0eee5 ",
+    "hex": "#f0eee5",
     "label": "K-935",
     "name": "Sierra Blanca"
   },
   {
-    "hex": "#665847 ",
+    "hex": "#665847",
     "label": "K-936",
     "name": "Mocha Mousse"
   },
   {
-    "hex": "#7a6b57 ",
+    "hex": "#7a6b57",
     "label": "K-937",
     "name": "CrËme de Caramel"
   },
   {
-    "hex": "#998c7a ",
+    "hex": "#998c7a",
     "label": "K-938",
     "name": "Tropical Tan"
   },
   {
-    "hex": "#b1a694 ",
+    "hex": "#b1a694",
     "label": "K-939",
     "name": "Bristol Beige"
   },
   {
-    "hex": "#cabca8 ",
+    "hex": "#cabca8",
     "label": "K-940",
     "name": "Bamboo Beach"
   },
   {
-    "hex": "#cec2af ",
+    "hex": "#cec2af",
     "label": "K-941",
     "name": "Sail Cloth "
   },
   {
-    "hex": "#e1d9ca ",
+    "hex": "#e1d9ca",
     "label": "K-942",
     "name": "Travertine Trail"
   },
   {
-    "hex": "#e8e2d6 ",
+    "hex": "#e8e2d6",
     "label": "K-943",
     "name": "Bridal Wreath"
   },
   {
-    "hex": "#615846 ",
+    "hex": "#615846",
     "label": "K-944",
     "name": "Stone Wall"
   },
   {
-    "hex": "#726959 ",
+    "hex": "#726959",
     "label": "K-945",
     "name": "Carlton Clay"
   },
   {
-    "hex": "#847b6a ",
+    "hex": "#847b6a",
     "label": "K-946",
     "name": "Rockvale"
   },
   {
-    "hex": "#989081 ",
+    "hex": "#989081",
     "label": "K-947",
     "name": "Utility Wear"
   },
   {
-    "hex": "#b3ac9e ",
+    "hex": "#b3ac9e",
     "label": "K-948",
     "name": "Homespun Linen"
   },
   {
-    "hex": "#cac1b1 ",
+    "hex": "#cac1b1",
     "label": "K-949",
     "name": "Star Light"
   },
   {
-    "hex": "#d8d0c2 ",
+    "hex": "#d8d0c2",
     "label": "K-950",
     "name": "Desert Palm"
   },
   {
-    "hex": "#e3dcd0 ",
+    "hex": "#e3dcd0",
     "label": "K-951",
     "name": "Savana Oaks"
   },
   {
-    "hex": "#50493b ",
+    "hex": "#50493b",
     "label": "K-952",
     "name": "Norwegian Wood"
   },
   {
-    "hex": "#72695c ",
+    "hex": "#72695c",
     "label": "K-953",
     "name": "Fair Fieldstone"
   },
   {
-    "hex": "#847b6d ",
+    "hex": "#847b6d",
     "label": "K-954",
     "name": "Greyswood"
   },
   {
-    "hex": "#a8a196 ",
+    "hex": "#a8a196",
     "label": "K-955",
     "name": "Wild Mushroom"
   },
   {
-    "hex": "#c7bfb2 ",
+    "hex": "#c7bfb2",
     "label": "K-956",
     "name": "Apollodorous"
   },
   {
-    "hex": "#d3cbbf ",
+    "hex": "#d3cbbf",
     "label": "K-957",
     "name": "Grey Ghost"
   },
   {
-    "hex": "#ded8ce ",
+    "hex": "#ded8ce",
     "label": "K-958",
     "name": "Sierra Snow"
   },
   {
-    "hex": "#eae6de ",
+    "hex": "#eae6de",
     "label": "K-959",
     "name": "White Now!"
   },
   {
-    "hex": "#726845 ",
+    "hex": "#726845",
     "label": "K-960",
     "name": "Woven Willow"
   },
   {
-    "hex": "#827d60 ",
+    "hex": "#827d60",
     "label": "K-961",
     "name": "Manchester Mood"
   },
   {
-    "hex": "#918b6e ",
+    "hex": "#918b6e",
     "label": "K-962",
     "name": "Sandalwood Tan"
   },
   {
-    "hex": "#a19d84 ",
+    "hex": "#a19d84",
     "label": "K-963",
     "name": "Head for the Beach"
   },
   {
-    "hex": "#cbc5ab ",
+    "hex": "#cbc5ab",
     "label": "K-964",
     "name": "Beach Bum"
   },
   {
-    "hex": "#d6d0b9 ",
+    "hex": "#d6d0b9",
     "label": "K-965",
     "name": "Sand Castle"
   },
   {
-    "hex": "#ebe8d9 ",
+    "hex": "#ebe8d9",
     "label": "K-966",
     "name": "Creamy Natural"
   },
   {
-    "hex": "#f2f0e6 ",
+    "hex": "#f2f0e6",
     "label": "K-967",
     "name": "Pale Face"
   },
   {
-    "hex": "#61543e ",
+    "hex": "#61543e",
     "label": "K-968",
     "name": "Olive Grove"
   },
   {
-    "hex": "#928266 ",
+    "hex": "#928266",
     "label": "K-969",
     "name": "African Plain"
   },
   {
-    "hex": "#a19276 ",
+    "hex": "#a19276",
     "label": "K-970",
     "name": "Highland Grass"
   },
   {
-    "hex": "#b0a38c ",
+    "hex": "#b0a38c",
     "label": "K-971",
     "name": "Westover Hills"
   },
   {
-    "hex": "#c8bda9 ",
+    "hex": "#c8bda9",
     "label": "K-972",
     "name": "Baja Beach"
   },
   {
-    "hex": "#e2d9c6 ",
+    "hex": "#e2d9c6",
     "label": "K-973",
     "name": "Bleached Burl"
   },
   {
-    "hex": "#e7e0d1 ",
+    "hex": "#e7e0d1",
     "label": "K-974",
     "name": "Meadow Day"
   },
   {
-    "hex": "#f0ebe0 ",
+    "hex": "#f0ebe0",
     "label": "K-975",
     "name": "Campiello"
   },
   {
-    "hex": "#8e7742 ",
+    "hex": "#8e7742",
     "label": "K-976",
     "name": "Brown Mountain"
   },
   {
-    "hex": "#a48d59 ",
+    "hex": "#a48d59",
     "label": "K-977",
     "name": "Sandhurst"
   },
   {
-    "hex": "#b29a67 ",
+    "hex": "#b29a67",
     "label": "K-978",
     "name": "Barefoot Beach"
   },
   {
-    "hex": "#beaa7d ",
+    "hex": "#beaa7d",
     "label": "K-979",
     "name": "Happy Camper"
   },
   {
-    "hex": "#d2c098 ",
+    "hex": "#d2c098",
     "label": "K-980",
     "name": "Western Wear"
   },
   {
-    "hex": "#e2d1a9 ",
+    "hex": "#e2d1a9",
     "label": "K-981",
     "name": "Dustry Trail"
   },
   {
-    "hex": "#f0e6cb ",
+    "hex": "#f0e6cb",
     "label": "K-982",
     "name": "Barely Dawn"
   },
   {
-    "hex": "#f3ecd8 ",
+    "hex": "#f3ecd8",
     "label": "K-983",
     "name": "Dover Tint"
   },
   {
-    "hex": "#826b42 ",
+    "hex": "#826b42",
     "label": "K-984",
     "name": "Cozy Cabin"
   },
   {
-    "hex": "#a0895c ",
+    "hex": "#a0895c",
     "label": "K-985",
     "name": "Woodriff"
   },
   {
-    "hex": "#b39c6f ",
+    "hex": "#b39c6f",
     "label": "K-986",
     "name": "Soft Moccasin"
   },
   {
-    "hex": "#bda882 ",
+    "hex": "#bda882",
     "label": "K-987",
     "name": "Serengeti Safari"
   },
   {
-    "hex": "#d3c2a0 ",
+    "hex": "#d3c2a0",
     "label": "K-988",
     "name": "Pale Portabella"
   },
   {
-    "hex": "#e2d3b2 ",
+    "hex": "#e2d3b2",
     "label": "K-989",
     "name": "Tropical Straw"
   },
   {
-    "hex": "#eee4cc ",
+    "hex": "#eee4cc",
     "label": "K-990",
     "name": "Organic Cotton"
   },
   {
-    "hex": "#f2ead8 ",
+    "hex": "#f2ead8",
     "label": "K-991",
     "name": "Cottage White"
   },
   {
-    "hex": "#9b733c ",
+    "hex": "#9b733c",
     "label": "K-992",
     "name": "Golden Mist"
   },
   {
-    "hex": "#b38c52 ",
+    "hex": "#b38c52",
     "label": "K-993",
     "name": "Golden Prairie"
   },
   {
-    "hex": "#bb955c ",
+    "hex": "#bb955c",
     "label": "K-994",
     "name": "Sheer Exposure"
   },
   {
-    "hex": "#cca978 ",
+    "hex": "#cca978",
     "label": "K-995",
     "name": "Balsam Brown"
   },
   {
-    "hex": "#dec197 ",
+    "hex": "#dec197",
     "label": "K-996",
     "name": "Ferncliffe"
   },
   {
-    "hex": "#ecd3a9 ",
+    "hex": "#ecd3a9",
     "label": "K-997",
     "name": "Skin Light"
   },
   {
-    "hex": "#f2e1c1 ",
+    "hex": "#f2e1c1",
     "label": "K-998",
     "name": "Aged Parchment"
   },
   {
-    "hex": "#f4ead0 ",
+    "hex": "#f4ead0",
     "label": "K-999",
     "name": "Cloud of Cream"
   },
   {
-    "hex": "#91714a ",
+    "hex": "#91714a",
     "label": "K-1000",
     "name": "Royal Crown"
   },
   {
-    "hex": "#a3855c ",
+    "hex": "#a3855c",
     "label": "K-1001",
     "name": "Mexican Hills"
   },
   {
-    "hex": "#b5986e ",
+    "hex": "#b5986e",
     "label": "K-1002",
     "name": "Gold Promise"
   },
   {
-    "hex": "#bfa37f ",
+    "hex": "#bfa37f",
     "label": "K-1003",
     "name": "Victorian Gold"
   },
   {
-    "hex": "#d4be9f ",
+    "hex": "#d4be9f",
     "label": "K-1004",
     "name": "Star of the Garden"
   },
   {
-    "hex": "#e3d1b1 ",
+    "hex": "#e3d1b1",
     "label": "K-1005",
     "name": "Simply Tan"
   },
   {
-    "hex": "#ecddc3 ",
+    "hex": "#ecddc3",
     "label": "K-1006",
     "name": "Limestone Ridge"
   },
   {
-    "hex": "#f0e5d0 ",
+    "hex": "#f0e5d0",
     "label": "K-1007",
     "name": "Golden Pastel"
   },
   {
-    "hex": "#906b42 ",
+    "hex": "#906b42",
     "label": "K-1008",
     "name": "Carmel Candy"
   },
   {
-    "hex": "#a27d56 ",
+    "hex": "#a27d56",
     "label": "K-1009",
     "name": "Caramel Mountain"
   },
   {
-    "hex": "#b08e67 ",
+    "hex": "#b08e67",
     "label": "K-1010",
     "name": "Tumble Tan"
   },
   {
-    "hex": "#bea17f ",
+    "hex": "#bea17f",
     "label": "K-1011",
     "name": "Bernard Beach"
   },
   {
-    "hex": "#d3b798 ",
+    "hex": "#d3b798",
     "label": "K-1012",
     "name": "Washed Khaki"
   },
   {
-    "hex": "#e3cbac ",
+    "hex": "#e3cbac",
     "label": "K-1013",
     "name": "Timothy Tan"
   },
   {
-    "hex": "#ebd9be ",
+    "hex": "#ebd9be",
     "label": "K-1014",
     "name": "Stilwell Beige"
   },
   {
-    "hex": "#f2e5d1 ",
+    "hex": "#f2e5d1",
     "label": "K-1015",
     "name": "Oat Straw"
   },
   {
-    "hex": "#775b41 ",
+    "hex": "#775b41",
     "label": "K-1016",
     "name": "Latte Please"
   },
   {
-    "hex": "#886c53 ",
+    "hex": "#886c53",
     "label": "K-1017",
     "name": "Dig It"
   },
   {
-    "hex": "#a48c75 ",
+    "hex": "#a48c75",
     "label": "K-1018",
     "name": "Pocahontas"
   },
   {
-    "hex": "#bea893 ",
+    "hex": "#bea893",
     "label": "K-1019",
     "name": "Swiss Cream"
   },
   {
-    "hex": "#d4bea6 ",
+    "hex": "#d4bea6",
     "label": "K-1020",
     "name": "Rocio"
   },
   {
-    "hex": "#dcc7b1 ",
+    "hex": "#dcc7b1",
     "label": "K-1021",
     "name": "Heritage Hills"
   },
   {
-    "hex": "#e6d6c3 ",
+    "hex": "#e6d6c3",
     "label": "K-1022",
     "name": "Tender Tan"
   },
   {
-    "hex": "#ede0d1 ",
+    "hex": "#ede0d1",
     "label": "K-1023",
     "name": "Whisper of White"
   },
   {
-    "hex": "#9f6e41 ",
+    "hex": "#9f6e41",
     "label": "K-1024",
     "name": "Fallen Leaf"
   },
   {
-    "hex": "#ae8157 ",
+    "hex": "#ae8157",
     "label": "K-1025",
     "name": "African Desert"
   },
   {
-    "hex": "#cba37e ",
+    "hex": "#cba37e",
     "label": "K-1026",
     "name": "Supreme Bean"
   },
   {
-    "hex": "#ddbc9b ",
+    "hex": "#ddbc9b",
     "label": "K-1027",
     "name": "Brownstone"
   },
   {
-    "hex": "#ebcfad ",
+    "hex": "#ebcfad",
     "label": "K-1028",
     "name": "Legato Lane"
   },
   {
-    "hex": "#eed6b8 ",
+    "hex": "#eed6b8",
     "label": "K-1029",
     "name": "Palace Hill "
   },
   {
-    "hex": "#f3e1c8 ",
+    "hex": "#f3e1c8",
     "label": "K-1030",
     "name": "Julesberg"
   },
   {
-    "hex": "#f5e8d5 ",
+    "hex": "#f5e8d5",
     "label": "K-1031",
     "name": "Navarro"
   },
   {
-    "hex": "#835d3d ",
+    "hex": "#835d3d",
     "label": "K-1032",
     "name": "Pinecone Path"
   },
   {
-    "hex": "#a07959 ",
+    "hex": "#a07959",
     "label": "K-1033",
     "name": "Wildwood Bay"
   },
   {
-    "hex": "#b18b68 ",
+    "hex": "#b18b68",
     "label": "K-1034",
     "name": "Rustic Charm"
   },
   {
-    "hex": "#be9b7e ",
+    "hex": "#be9b7e",
     "label": "K-1035",
     "name": "Earthy Tan"
   },
   {
-    "hex": "#d3b399 ",
+    "hex": "#d3b399",
     "label": "K-1036",
     "name": "Early Tan"
   },
   {
-    "hex": "#e7ceb3 ",
+    "hex": "#e7ceb3",
     "label": "K-1037",
     "name": "Regina Beach"
   },
   {
-    "hex": "#ebd6be ",
+    "hex": "#ebd6be",
     "label": "K-1038",
     "name": "Dune Walk"
   },
   {
-    "hex": "#f3e8d8 ",
+    "hex": "#f3e8d8",
     "label": "K-1039",
     "name": "Sandollar Beach"
   },
   {
-    "hex": "#886144 ",
+    "hex": "#886144",
     "label": "K-1040",
     "name": "Mochaccino"
   },
   {
-    "hex": "#997354 ",
+    "hex": "#997354",
     "label": "K-1041",
     "name": "Burnished Caramel"
   },
   {
-    "hex": "#a68265 ",
+    "hex": "#a68265",
     "label": "K-1042",
     "name": "Benetello"
   },
   {
-    "hex": "#b39277 ",
+    "hex": "#b39277",
     "label": "K-1043",
     "name": "Country Life"
   },
   {
-    "hex": "#ceb097 ",
+    "hex": "#ceb097",
     "label": "K-1044",
     "name": "Soft Buckskin"
   },
   {
-    "hex": "#dfc4a9 ",
+    "hex": "#dfc4a9",
     "label": "K-1045",
     "name": "Sandunia"
   },
   {
-    "hex": "#e8d2bb ",
+    "hex": "#e8d2bb",
     "label": "K-1046",
     "name": "Baked Biscuit"
   },
   {
-    "hex": "#f0e3d3 ",
+    "hex": "#f0e3d3",
     "label": "K-1047",
     "name": "Bare Bone"
   },
   {
-    "hex": "#7c5539 ",
+    "hex": "#7c5539",
     "label": "K-1048",
     "name": "Western Pursuit"
   },
   {
-    "hex": "#977055 ",
+    "hex": "#977055",
     "label": "K-1049",
     "name": "Maple Sugar"
   },
   {
-    "hex": "#a88266 ",
+    "hex": "#a88266",
     "label": "K-1050",
     "name": "Carmel Valley"
   },
   {
-    "hex": "#b18e76 ",
+    "hex": "#b18e76",
     "label": "K-1051",
     "name": "Sandy's Shores"
   },
   {
-    "hex": "#cbab95 ",
+    "hex": "#cbab95",
     "label": "K-1052",
     "name": "Sands of Time"
   },
   {
-    "hex": "#ddc0a8 ",
+    "hex": "#ddc0a8",
     "label": "K-1053",
     "name": "Big on Beige "
   },
   {
-    "hex": "#ebd7c4 ",
+    "hex": "#ebd7c4",
     "label": "K-1054",
     "name": "Fair Ivory"
   },
   {
-    "hex": "#f2e9dc ",
+    "hex": "#f2e9dc",
     "label": "K-1055",
     "name": "Bare Essential"
   },
   {
-    "hex": "#a06339 ",
+    "hex": "#a06339",
     "label": "K-1056",
     "name": "Warrior King"
   },
   {
-    "hex": "#b57950 ",
+    "hex": "#b57950",
     "label": "K-1057",
     "name": "Chamois Shirt"
   },
   {
-    "hex": "#ce9771 ",
+    "hex": "#ce9771",
     "label": "K-1058",
     "name": "Vizcaino Desert"
   },
   {
-    "hex": "#e1b392 ",
+    "hex": "#e1b392",
     "label": "K-1059",
     "name": "Fresh Sawdust"
   },
   {
-    "hex": "#eec7a5 ",
+    "hex": "#eec7a5",
     "label": "K-1060",
     "name": "Beachville"
   },
   {
-    "hex": "#f1cfb0 ",
+    "hex": "#f1cfb0",
     "label": "K-1061",
     "name": "Taffy Surprise"
   },
   {
-    "hex": "#f5dbc1 ",
+    "hex": "#f5dbc1",
     "label": "K-1062",
     "name": "Beach Walk"
   },
   {
-    "hex": "#f6ebdb ",
+    "hex": "#f6ebdb",
     "label": "K-1063",
     "name": "Crystal Beach"
   },
   {
-    "hex": "#714c3b ",
+    "hex": "#714c3b",
     "label": "K-1064",
     "name": "Soul of the Earth"
   },
   {
-    "hex": "#a37255 ",
+    "hex": "#a37255",
     "label": "K-1065",
     "name": "Terrific Tan"
   },
   {
-    "hex": "#b58669 ",
+    "hex": "#b58669",
     "label": "K-1066",
     "name": "Brighton Beach"
   },
   {
-    "hex": "#c2977e ",
+    "hex": "#c2977e",
     "label": "K-1067",
     "name": "Southwest Sand"
   },
   {
-    "hex": "#d1a992 ",
+    "hex": "#d1a992",
     "label": "K-1068",
     "name": "Beauty and the Beach"
   },
   {
-    "hex": "#e1bfa5 ",
+    "hex": "#e1bfa5",
     "label": "K-1069",
     "name": "Face of Innocence"
   },
   {
-    "hex": "#f0dbc8 ",
+    "hex": "#f0dbc8",
     "label": "K-1070",
     "name": "Sunwashed Beach"
   },
   {
-    "hex": "#f4e5d6 ",
+    "hex": "#f4e5d6",
     "label": "K-1071",
     "name": "Moongaze"
   },
   {
-    "hex": "#9f4d38 ",
+    "hex": "#9f4d38",
     "label": "K-1072",
     "name": "Truffle Trouble"
   },
   {
-    "hex": "#a96348 ",
+    "hex": "#a96348",
     "label": "K-1073",
     "name": "Rustic Hills"
   },
   {
-    "hex": "#c1816b ",
+    "hex": "#c1816b",
     "label": "K-1074",
     "name": "Spice Island"
   },
   {
-    "hex": "#d8a08b ",
+    "hex": "#d8a08b",
     "label": "K-1075",
     "name": "Copperfield"
   },
   {
-    "hex": "#e7b69e ",
+    "hex": "#e7b69e",
     "label": "K-1076",
     "name": "Ancient Inca"
   },
   {
-    "hex": "#e9b9a3 ",
+    "hex": "#e9b9a3",
     "label": "K-1077",
     "name": "Doug's Dale"
   },
   {
-    "hex": "#f1ccb9 ",
+    "hex": "#f1ccb9",
     "label": "K-1078",
     "name": "Tangier Tan"
   },
   {
-    "hex": "#f6dfd0 ",
+    "hex": "#f6dfd0",
     "label": "K-1079",
     "name": "Mariah"
   },
   {
-    "hex": "#8a4e37 ",
+    "hex": "#8a4e37",
     "label": "K-1080",
     "name": "Old Brick"
   },
   {
-    "hex": "#a5644d ",
+    "hex": "#a5644d",
     "label": "K-1081",
     "name": "Fox Wood"
   },
   {
-    "hex": "#b4745e ",
+    "hex": "#b4745e",
     "label": "K-1082",
     "name": "Copper Coast"
   },
   {
-    "hex": "#cb9583 ",
+    "hex": "#cb9583",
     "label": "K-1083",
     "name": "Rustic Pottery"
   },
   {
-    "hex": "#d9a797 ",
+    "hex": "#d9a797",
     "label": "K-1084",
     "name": "Sunbaked Clay"
   },
   {
-    "hex": "#e6bba8 ",
+    "hex": "#e6bba8",
     "label": "K-1085",
     "name": "Wasaga Beach"
   },
   {
-    "hex": "#f2d4c5 ",
+    "hex": "#f2d4c5",
     "label": "K-1086",
     "name": "In the Buff"
   },
   {
-    "hex": "#f6e7dd ",
+    "hex": "#f6e7dd",
     "label": "K-1087",
     "name": "Kensington"
   },
   {
-    "hex": "#8b3c2a ",
+    "hex": "#8b3c2a",
     "label": "K-1088",
     "name": "Majestic Ridge"
   },
   {
-    "hex": "#af6049 ",
+    "hex": "#af6049",
     "label": "K-1089",
     "name": "Pebblestone Clay"
   },
   {
-    "hex": "#c57c69 ",
+    "hex": "#c57c69",
     "label": "K-1090",
     "name": "Prairie Island"
   },
   {
-    "hex": "#dc9886 ",
+    "hex": "#dc9886",
     "label": "K-1091",
     "name": "Rocky Cliff"
   },
   {
-    "hex": "#eaac96 ",
+    "hex": "#eaac96",
     "label": "K-1092",
     "name": "Timber Ridge"
   },
   {
-    "hex": "#f3c8b6 ",
+    "hex": "#f3c8b6",
     "label": "K-1093",
     "name": "Stoney Creek"
   },
   {
-    "hex": "#f8e0d4 ",
+    "hex": "#f8e0d4",
     "label": "K-1094",
     "name": "Fresh Air"
   },
   {
-    "hex": "#f6ede3 ",
+    "hex": "#f6ede3",
     "label": "K-1095",
     "name": "Abbey Lane"
   },
   {
-    "hex": "#693834 ",
+    "hex": "#693834",
     "label": "K-1096",
     "name": "Spice Variety"
   },
   {
-    "hex": "#935a4b ",
+    "hex": "#935a4b",
     "label": "K-1097",
     "name": "Southwest Spirit"
   },
   {
-    "hex": "#a46c5d ",
+    "hex": "#a46c5d",
     "label": "K-1098",
     "name": "Point Sienna"
   },
   {
-    "hex": "#c39388 ",
+    "hex": "#c39388",
     "label": "K-1099",
     "name": "Topaz Tease"
   },
   {
-    "hex": "#d7a99b ",
+    "hex": "#d7a99b",
     "label": "K-1100",
     "name": "Warm Sands"
   },
   {
-    "hex": "#e2baae ",
+    "hex": "#e2baae",
     "label": "K-1101",
     "name": "Parma"
   },
   {
-    "hex": "#eaccc0 ",
+    "hex": "#eaccc0",
     "label": "K-1102",
     "name": "Almond Kiss"
   },
   {
-    "hex": "#f1d9cf ",
+    "hex": "#f1d9cf",
     "label": "K-1103",
     "name": "Bleached Ivory "
   },
   {
-    "hex": "#654737 ",
+    "hex": "#654737",
     "label": "K-1104",
     "name": "Bistro Brown"
   },
   {
-    "hex": "#7f5f51 ",
+    "hex": "#7f5f51",
     "label": "K-1105",
     "name": "Mocha Java"
   },
   {
-    "hex": "#997a6c ",
+    "hex": "#997a6c",
     "label": "K-1106",
     "name": "Pale Palamino"
   },
   {
-    "hex": "#a88c81 ",
+    "hex": "#a88c81",
     "label": "K-1107",
     "name": "Reuben Ridge"
   },
   {
-    "hex": "#baa096 ",
+    "hex": "#baa096",
     "label": "K-1108",
     "name": "Stream Stone"
   },
   {
-    "hex": "#cfb6a9 ",
+    "hex": "#cfb6a9",
     "label": "K-1109",
     "name": "Sandstorm"
   },
   {
-    "hex": "#ddc6bb ",
+    "hex": "#ddc6bb",
     "label": "K-1110",
     "name": "Beach Bound"
   },
   {
-    "hex": "#ece0d7 ",
+    "hex": "#ece0d7",
     "label": "K-1111",
     "name": "Beige Bluff"
   },
   {
-    "hex": "#523c32 ",
+    "hex": "#523c32",
     "label": "K-1112",
     "name": "Jeff's Java"
   },
   {
-    "hex": "#715a50 ",
+    "hex": "#715a50",
     "label": "K-1113",
     "name": "Light Roast"
   },
   {
-    "hex": "#8a7268 ",
+    "hex": "#8a7268",
     "label": "K-1114",
     "name": "Mocha CafÈ"
   },
   {
-    "hex": "#ac9992 ",
+    "hex": "#ac9992",
     "label": "K-1115",
     "name": "Open Road"
   },
   {
-    "hex": "#c2afa5 ",
+    "hex": "#c2afa5",
     "label": "K-1116",
     "name": "Dancing Deer"
   },
   {
-    "hex": "#cdbbb1 ",
+    "hex": "#cdbbb1",
     "label": "K-1117",
     "name": "Roanoke"
   },
   {
-    "hex": "#dbcbc2 ",
+    "hex": "#dbcbc2",
     "label": "K-1118",
     "name": "Pale Starlet"
   },
   {
-    "hex": "#ece1d9 ",
+    "hex": "#ece1d9",
     "label": "K-1119",
     "name": "Turkish Towel"
   },
   {
-    "hex": "#8a3d36 ",
+    "hex": "#8a3d36",
     "label": "K-1120",
     "name": "Autumn's Bronze"
   },
   {
-    "hex": "#a55144 ",
+    "hex": "#a55144",
     "label": "K-1121",
     "name": "Penny Lane"
   },
   {
-    "hex": "#b5665b ",
+    "hex": "#b5665b",
     "label": "K-1122",
     "name": "Ginger Jar"
   },
   {
-    "hex": "#cf857b ",
+    "hex": "#cf857b",
     "label": "K-1123",
     "name": "Cinnamon Rose"
   },
   {
-    "hex": "#ebada1 ",
+    "hex": "#ebada1",
     "label": "K-1124",
     "name": "Tuscan Trail"
   },
   {
-    "hex": "#f2bfb4 ",
+    "hex": "#f2bfb4",
     "label": "K-1125",
     "name": "Coral Bells"
   },
   {
-    "hex": "#f7d8ce ",
+    "hex": "#f7d8ce",
     "label": "K-1126",
     "name": "Rogue Bluff"
   },
   {
-    "hex": "#f6e9e2 ",
+    "hex": "#f6e9e2",
     "label": "K-1127",
     "name": "Castleford"
   },
   {
-    "hex": "#682f34 ",
+    "hex": "#682f34",
     "label": "K-1128",
     "name": "Wendy Way"
   },
   {
-    "hex": "#825757 ",
+    "hex": "#825757",
     "label": "K-1129",
     "name": "Chocolate Cherry"
   },
   {
-    "hex": "#987475 ",
+    "hex": "#987475",
     "label": "K-1130",
     "name": "Roshen Ridge"
   },
   {
-    "hex": "#b59595 ",
+    "hex": "#b59595",
     "label": "K-1131",
     "name": "Taryn Hills"
   },
   {
-    "hex": "#ccaba9 ",
+    "hex": "#ccaba9",
     "label": "K-1132",
     "name": "Demetrio"
   },
   {
-    "hex": "#d9bebc ",
+    "hex": "#d9bebc",
     "label": "K-1133",
     "name": "Chambord Charm"
   },
   {
-    "hex": "#e5cdca ",
+    "hex": "#e5cdca",
     "label": "K-1134",
     "name": "Mohican Mist"
   },
   {
-    "hex": "#ecdbd8 ",
+    "hex": "#ecdbd8",
     "label": "K-1135",
     "name": "Soft Sunrise"
   },
   {
-    "hex": "#783c3f ",
+    "hex": "#783c3f",
     "label": "K-1136",
     "name": "Cheerful Cherry"
   },
   {
-    "hex": "#8d6266 ",
+    "hex": "#8d6266",
     "label": "K-1137",
     "name": "Spring Bliss"
   },
   {
-    "hex": "#a77f87 ",
+    "hex": "#a77f87",
     "label": "K-1138",
     "name": "Darius Dawn"
   },
   {
-    "hex": "#c09da4 ",
+    "hex": "#c09da4",
     "label": "K-1139",
     "name": "Pampered Pink"
   },
   {
-    "hex": "#d6b2b6 ",
+    "hex": "#d6b2b6",
     "label": "K-1140",
     "name": "Spring Thing"
   },
   {
-    "hex": "#e1c4c6 ",
+    "hex": "#e1c4c6",
     "label": "K-1141",
     "name": "Think About It"
   },
   {
-    "hex": "#ecd7d7 ",
+    "hex": "#ecd7d7",
     "label": "K-1142",
     "name": "Prelude to Pink"
   },
   {
-    "hex": "#f1e2e1 ",
+    "hex": "#f1e2e1",
     "label": "K-1143",
     "name": "Pillow Talk"
   },
   {
-    "hex": "#723747 ",
+    "hex": "#723747",
     "label": "K-1144",
     "name": "Very Berry"
   },
   {
-    "hex": "#9f6a73 ",
+    "hex": "#9f6a73",
     "label": "K-1145",
     "name": "Rosey Glow"
   },
   {
-    "hex": "#b78792 ",
+    "hex": "#b78792",
     "label": "K-1146",
     "name": "Rose Antiqua"
   },
   {
-    "hex": "#d1a7b1 ",
+    "hex": "#d1a7b1",
     "label": "K-1147",
     "name": "Noah's Ark"
   },
   {
-    "hex": "#e4bcc3 ",
+    "hex": "#e4bcc3",
     "label": "K-1148",
     "name": "Laureate"
   },
   {
-    "hex": "#ebcacf ",
+    "hex": "#ebcacf",
     "label": "K-1149",
     "name": "Spring Sprig"
   },
   {
-    "hex": "#f0d6d7 ",
+    "hex": "#f0d6d7",
     "label": "K-1150",
     "name": "Pearl Pink"
   },
   {
-    "hex": "#f4e1e1 ",
+    "hex": "#f4e1e1",
     "label": "K-1151",
     "name": "Arctic Lights"
   },
   {
-    "hex": "#794550 ",
+    "hex": "#794550",
     "label": "K-1152",
     "name": "Wine Country"
   },
   {
-    "hex": "#936168 ",
+    "hex": "#936168",
     "label": "K-1153",
     "name": "Mi Amor"
   },
   {
-    "hex": "#ad7f89 ",
+    "hex": "#ad7f89",
     "label": "K-1154",
     "name": "Merry Meredith"
   },
   {
-    "hex": "#c69fa7 ",
+    "hex": "#c69fa7",
     "label": "K-1155",
     "name": "Cosmos Kiss"
   },
   {
-    "hex": "#d6b3ba ",
+    "hex": "#d6b3ba",
     "label": "K-1156",
     "name": "Shrub Rose"
   },
   {
-    "hex": "#dcbbc1 ",
+    "hex": "#dcbbc1",
     "label": "K-1157",
     "name": "Andrea's Anticipation"
   },
   {
-    "hex": "#ead2d7 ",
+    "hex": "#ead2d7",
     "label": "K-1158",
     "name": "Easterville"
   },
   {
-    "hex": "#f3e6e5 ",
+    "hex": "#f3e6e5",
     "label": "K-1159",
     "name": "Soft Shell"
   },
   {
-    "hex": "#553f39 ",
+    "hex": "#553f39",
     "label": "K-1160",
     "name": "Dame Margaret"
   },
   {
-    "hex": "#6c5652 ",
+    "hex": "#6c5652",
     "label": "K-1161",
     "name": "Powderhorn Manor"
   },
   {
-    "hex": "#857271 ",
+    "hex": "#857271",
     "label": "K-1162",
     "name": "Rave Raisin"
   },
   {
-    "hex": "#a49191 ",
+    "hex": "#a49191",
     "label": "K-1163",
     "name": "Luberon"
   },
   {
-    "hex": "#bda9a5 ",
+    "hex": "#bda9a5",
     "label": "K-1164",
     "name": "Toasted Rose"
   },
   {
-    "hex": "#cdbbb7 ",
+    "hex": "#cdbbb7",
     "label": "K-1165",
     "name": "Mauve Star"
   },
   {
-    "hex": "#dbccc7 ",
+    "hex": "#dbccc7",
     "label": "K-1166",
     "name": "Natalia"
   },
   {
-    "hex": "#ebe2df ",
+    "hex": "#ebe2df",
     "label": "K-1167",
     "name": "Soothing Spring"
   },
   {
-    "hex": "#463730 ",
+    "hex": "#463730",
     "label": "K-1168",
     "name": "Wrightsford"
   },
   {
-    "hex": "#705f57 ",
+    "hex": "#705f57",
     "label": "K-1169",
     "name": "Mohawk Valley"
   },
   {
-    "hex": "#7d6b62 ",
+    "hex": "#7d6b62",
     "label": "K-1170",
     "name": "Toasted Taupe"
   },
   {
-    "hex": "#90817b ",
+    "hex": "#90817b",
     "label": "K-1171",
     "name": "Utopia"
   },
   {
-    "hex": "#a99c96 ",
+    "hex": "#a99c96",
     "label": "K-1172",
     "name": "Gypsum Gap"
   },
   {
-    "hex": "#c5b7ad ",
+    "hex": "#c5b7ad",
     "label": "K-1173",
     "name": "Castellina"
   },
   {
-    "hex": "#d4c8c0 ",
+    "hex": "#d4c8c0",
     "label": "K-1174",
     "name": "Avorio"
   },
   {
-    "hex": "#dfd5cd ",
+    "hex": "#dfd5cd",
     "label": "K-1175",
     "name": "Miguel Angel"
   },
   {
-    "hex": "#5e4e3f ",
+    "hex": "#5e4e3f",
     "label": "K-1176",
     "name": "Coffee Connoisseur"
   },
   {
-    "hex": "#736557 ",
+    "hex": "#736557",
     "label": "K-1177",
     "name": "Evening Shade"
   },
   {
-    "hex": "#88796b ",
+    "hex": "#88796b",
     "label": "K-1178",
     "name": "Woodbridge"
   },
   {
-    "hex": "#978b80 ",
+    "hex": "#978b80",
     "label": "K-1179",
     "name": "Old English Castle"
   },
   {
-    "hex": "#b1a69b ",
+    "hex": "#b1a69b",
     "label": "K-1180",
     "name": "Kelmscott"
   },
   {
-    "hex": "#c7bbad ",
+    "hex": "#c7bbad",
     "label": "K-1181",
     "name": "Master Manuel"
   },
   {
-    "hex": "#dbd1c5 ",
+    "hex": "#dbd1c5",
     "label": "K-1182",
     "name": "Olympic Circle"
   },
   {
-    "hex": "#e8e2d9 ",
+    "hex": "#e8e2d9",
     "label": "K-1183",
     "name": "Lamb's Wool"
   },
   {
-    "hex": "#5f4a39 ",
+    "hex": "#5f4a39",
     "label": "K-1184",
     "name": "Shady Side"
   },
   {
-    "hex": "#7e6b5c ",
+    "hex": "#7e6b5c",
     "label": "K-1185",
     "name": "Brown Town"
   },
   {
-    "hex": "#927f70 ",
+    "hex": "#927f70",
     "label": "K-1186",
     "name": "Java 'n Cream"
   },
   {
-    "hex": "#a29285 ",
+    "hex": "#a29285",
     "label": "K-1187",
     "name": "Faded Beige"
   },
   {
-    "hex": "#b4a599 ",
+    "hex": "#b4a599",
     "label": "K-1188",
     "name": "Taupe View"
   },
   {
-    "hex": "#cbbbac ",
+    "hex": "#cbbbac",
     "label": "K-1189",
     "name": "Beige Rage"
   },
   {
-    "hex": "#ded3c7 ",
+    "hex": "#ded3c7",
     "label": "K-1190",
     "name": "Pink Fluff"
   },
   {
-    "hex": "#eee7de ",
+    "hex": "#eee7de",
     "label": "K-1191",
     "name": "Mountain Peak"
   },
   {
-    "hex": "#604a38 ",
+    "hex": "#604a38",
     "label": "K-1192",
     "name": "Cranberry Craze"
   },
   {
-    "hex": "#7b6656 ",
+    "hex": "#7b6656",
     "label": "K-1193",
     "name": "Cameroon Bay"
   },
   {
-    "hex": "#988577 ",
+    "hex": "#988577",
     "label": "K-1194",
     "name": "Antigua Rose"
   },
   {
-    "hex": "#b19f91 ",
+    "hex": "#b19f91",
     "label": "K-1195",
     "name": "Ashbury"
   },
   {
-    "hex": "#c7b5a4 ",
+    "hex": "#c7b5a4",
     "label": "K-1196",
     "name": "Beach Party"
   },
   {
-    "hex": "#d5c6b7 ",
+    "hex": "#d5c6b7",
     "label": "K-1197",
     "name": "Walnut Cream"
   },
   {
-    "hex": "#e2d6c8 ",
+    "hex": "#e2d6c8",
     "label": "K-1198",
     "name": "Canton Cotton"
   },
   {
-    "hex": "#e9dfd4 ",
+    "hex": "#e9dfd4",
     "label": "K-1199",
     "name": "Southern Sand"
   },
   {
-    "hex": "#d9bb24 ",
+    "hex": "#d9bb24",
     "label": "K-1200",
     "name": "Cancun Gold"
   },
   {
-    "hex": "#d2b11d ",
+    "hex": "#d2b11d",
     "label": "K-1201",
     "name": "Mustard Field"
   },
   {
-    "hex": "#eec400 ",
+    "hex": "#eec400",
     "label": "K-1202",
     "name": "Cha Cha"
   },
   {
-    "hex": "#fdd31d ",
+    "hex": "#fdd31d",
     "label": "K-1203",
     "name": "Sporty Yellow"
   },
   {
-    "hex": "#ffcf00 ",
+    "hex": "#ffcf00",
     "label": "K-1204",
     "name": "Lemon Ole'"
   },
   {
-    "hex": "#bf9334 ",
+    "hex": "#bf9334",
     "label": "K-1205",
     "name": "End of the Rainbow"
   },
   {
-    "hex": "#da9e19 ",
+    "hex": "#da9e19",
     "label": "K-1206",
     "name": "Curry Flurry"
   },
   {
-    "hex": "#bf8d38 ",
+    "hex": "#bf8d38",
     "label": "K-1207",
     "name": "Gold Trinket"
   },
   {
-    "hex": "#ffb700 ",
+    "hex": "#ffb700",
     "label": "K-1208",
     "name": "Bright'n Shiny"
   },
   {
-    "hex": "#ffa521 ",
+    "hex": "#ffa521",
     "label": "K-1209",
     "name": "Gilded Vision"
   },
   {
-    "hex": "#f89026 ",
+    "hex": "#f89026",
     "label": "K-1210",
     "name": "Glorious Sunset"
   },
   {
-    "hex": "#e87931 ",
+    "hex": "#e87931",
     "label": "K-1211",
     "name": "Glowing Ember"
   },
   {
-    "hex": "#e3622f ",
+    "hex": "#e3622f",
     "label": "K-1212",
     "name": "L'Orange"
   },
   {
-    "hex": "#f86f29 ",
+    "hex": "#f86f29",
     "label": "K-1213",
     "name": "Light My Fire"
   },
   {
-    "hex": "#e64e2b ",
+    "hex": "#e64e2b",
     "label": "K-1214",
     "name": "Montana Dust"
   },
   {
-    "hex": "#aa4832 ",
+    "hex": "#aa4832",
     "label": "K-1215",
     "name": "High Society"
   },
   {
-    "hex": "#c44538 ",
+    "hex": "#c44538",
     "label": "K-1216",
     "name": "China Rouge"
   },
   {
-    "hex": "#a0392f ",
+    "hex": "#a0392f",
     "label": "K-1217",
     "name": "Leaf Rust"
   },
   {
-    "hex": "#dd402e ",
+    "hex": "#dd402e",
     "label": "K-1218",
     "name": "Boing!"
   },
   {
-    "hex": "#c4342d ",
+    "hex": "#c4342d",
     "label": "K-1219",
     "name": "Red Red"
   },
   {
-    "hex": "#bd2e32 ",
+    "hex": "#bd2e32",
     "label": "K-1220",
     "name": "Lipstick Pencil"
   },
   {
-    "hex": "#c13d44 ",
+    "hex": "#c13d44",
     "label": "K-1221",
     "name": "Rosie O'Dell"
   },
   {
-    "hex": "#952d3a ",
+    "hex": "#952d3a",
     "label": "K-1222",
     "name": "American Rose"
   },
   {
-    "hex": "#ab2e46 ",
+    "hex": "#ab2e46",
     "label": "K-1223",
     "name": "Red Alert"
   },
   {
-    "hex": "#a93851 ",
+    "hex": "#a93851",
     "label": "K-1224",
     "name": "Red Blush"
   },
   {
-    "hex": "#ae3d55 ",
+    "hex": "#ae3d55",
     "label": "K-1225",
     "name": "Merlot Magic"
   },
   {
-    "hex": "#64403f ",
+    "hex": "#64403f",
     "label": "K-1226",
     "name": "Red Raisin"
   },
   {
-    "hex": "#6e3940 ",
+    "hex": "#6e3940",
     "label": "K-1227",
     "name": "Dark Cherry Tart"
   },
   {
-    "hex": "#803740 ",
+    "hex": "#803740",
     "label": "K-1228",
     "name": "Bright Burgundy"
   },
   {
-    "hex": "#80444c ",
+    "hex": "#80444c",
     "label": "K-1229",
     "name": "Raspberry Crush"
   },
   {
-    "hex": "#933851 ",
+    "hex": "#933851",
     "label": "K-1230",
     "name": "Teahouse Rose"
   },
   {
-    "hex": "#ae3162 ",
+    "hex": "#ae3162",
     "label": "K-1231",
     "name": "Valentine's Kiss"
   },
   {
-    "hex": "#8e3155 ",
+    "hex": "#8e3155",
     "label": "K-1232",
     "name": "Dark Burgundy Wine"
   },
   {
-    "hex": "#593843 ",
+    "hex": "#593843",
     "label": "K-1233",
     "name": "Plumbago"
   },
   {
-    "hex": "#663149 ",
+    "hex": "#663149",
     "label": "K-1234",
     "name": "Cherry Bon Bon"
   },
   {
-    "hex": "#753656 ",
+    "hex": "#753656",
     "label": "K-1235",
     "name": "Gailberry"
   },
   {
-    "hex": "#8e3463 ",
+    "hex": "#8e3463",
     "label": "K-1236",
     "name": "Fools' Fuscia"
   },
   {
-    "hex": "#94437c ",
+    "hex": "#94437c",
     "label": "K-1237",
     "name": "Grape Riot"
   },
   {
-    "hex": "#713b5e ",
+    "hex": "#713b5e",
     "label": "K-1238",
     "name": "Lavender Suede"
   },
   {
-    "hex": "#693d67 ",
+    "hex": "#693d67",
     "label": "K-1239",
     "name": "Floral Paradise"
   },
   {
-    "hex": "#583b64 ",
+    "hex": "#583b64",
     "label": "K-1240",
     "name": "Passion's Plea"
   },
   {
-    "hex": "#394778 ",
+    "hex": "#394778",
     "label": "K-1241",
     "name": "Sailor's Eyes"
   },
   {
-    "hex": "#38405d ",
+    "hex": "#38405d",
     "label": "K-1242",
     "name": "Royal Wave"
   },
   {
-    "hex": "#30466b ",
+    "hex": "#30466b",
     "label": "K-1243",
     "name": "Midnight Interlude"
   },
   {
-    "hex": "#274b71 ",
+    "hex": "#274b71",
     "label": "K-1244",
     "name": "Inky Sea"
   },
   {
-    "hex": "#005488 ",
+    "hex": "#005488",
     "label": "K-1245",
     "name": "Wavy Navy"
   },
   {
-    "hex": "#006c92 ",
+    "hex": "#006c92",
     "label": "K-1246",
     "name": "Ahoy! Blue"
   },
   {
-    "hex": "#21526c ",
+    "hex": "#21526c",
     "label": "K-1247",
     "name": "Teal Shadow"
   },
   {
-    "hex": "#006c80 ",
+    "hex": "#006c80",
     "label": "K-1248",
     "name": "Great Blue Green"
   },
   {
-    "hex": "#244954 ",
+    "hex": "#244954",
     "label": "K-1249",
     "name": "Sophisticated Teal"
   },
   {
-    "hex": "#245a61 ",
+    "hex": "#245a61",
     "label": "K-1250",
     "name": "Turquoise Ocean"
   },
   {
-    "hex": "#205258 ",
+    "hex": "#205258",
     "label": "K-1251",
     "name": "Deep Sea Dream"
   },
   {
-    "hex": "#305e51 ",
+    "hex": "#305e51",
     "label": "K-1252",
     "name": "Deep Loden Green"
   },
   {
-    "hex": "#386651 ",
+    "hex": "#386651",
     "label": "K-1253",
     "name": "Glory Green"
   },
   {
-    "hex": "#096845 ",
+    "hex": "#096845",
     "label": "K-1254",
     "name": "Emerald Lights"
   },
   {
-    "hex": "#0e7046 ",
+    "hex": "#0e7046",
     "label": "K-1255",
     "name": "Hill and Vale"
   },
   {
-    "hex": "#476849 ",
+    "hex": "#476849",
     "label": "K-1256",
     "name": "Shamrock Charm"
   },
   {
-    "hex": "#538742 ",
+    "hex": "#538742",
     "label": "K-1257",
     "name": "Fair Lady Kelly"
   },
   {
-    "hex": "#63b125 ",
+    "hex": "#63b125",
     "label": "K-1258",
     "name": "Lots of Lime"
   },
   {
-    "hex": "#6c8b44 ",
+    "hex": "#6c8b44",
     "label": "K-1259",
     "name": "Baby Sprout"
   },
   {
-    "hex": "#f5f2e6 ",
+    "hex": "#f5f2e6",
     "label": "K-1260",
     "name": "Swan Wing"
   },
   {
-    "hex": "#f5f2e8 ",
+    "hex": "#f5f2e8",
     "label": "K-1261",
     "name": "Genna"
   },
   {
-    "hex": "#f6f3e9 ",
+    "hex": "#f6f3e9",
     "label": "K-1262",
     "name": "Beyond Pale"
   },
   {
-    "hex": "#f4f1ea ",
+    "hex": "#f4f1ea",
     "label": "K-1263",
     "name": "Country Cotton"
   },
   {
-    "hex": "#f5f3ea ",
+    "hex": "#f5f3ea",
     "label": "K-1264",
     "name": "Soap Suds"
   },
   {
-    "hex": "#f3f2ea ",
+    "hex": "#f3f2ea",
     "label": "K-1265",
     "name": "Apple White"
   },
   {
-    "hex": "#f0ece8 ",
+    "hex": "#f0ece8",
     "label": "K-1266",
     "name": "Bridal Bouquet"
   },
   {
-    "hex": "#eceee9 ",
+    "hex": "#eceee9",
     "label": "K-1267",
     "name": "Birch Bay"
   },
   {
-    "hex": "#e8e9e1 ",
+    "hex": "#e8e9e1",
     "label": "K-1268",
     "name": "White Mountain"
   },
   {
-    "hex": "#edf2ec ",
+    "hex": "#edf2ec",
     "label": "K-1269",
     "name": "Crystal Peak"
   },
   {
-    "hex": "#e6ede9 ",
+    "hex": "#e6ede9",
     "label": "K-1270",
     "name": "Sheer Ice"
   },
   {
-    "hex": "#edf4ec ",
+    "hex": "#edf4ec",
     "label": "K-1271",
     "name": "White Echo"
   },
   {
-    "hex": "#e9f2ea ",
+    "hex": "#e9f2ea",
     "label": "K-1272",
     "name": "Seagull Point"
   },
   {
-    "hex": "#e0f0ed ",
+    "hex": "#e0f0ed",
     "label": "K-1273",
     "name": "Aqua Silence"
   },
   {
-    "hex": "#e2f0e8 ",
+    "hex": "#e2f0e8",
     "label": "K-1274",
     "name": "White Bisque"
   },
   {
-    "hex": "#e8f3e8 ",
+    "hex": "#e8f3e8",
     "label": "K-1275",
     "name": "Mint Taffy"
   },
   {
-    "hex": "#e8f2e8 ",
+    "hex": "#e8f2e8",
     "label": "K-1276",
     "name": "Aurora Splendor"
   },
   {
-    "hex": "#ecf2ea ",
+    "hex": "#ecf2ea",
     "label": "K-1277",
     "name": "Waterfall Mist"
   },
   {
-    "hex": "#eef4ea ",
+    "hex": "#eef4ea",
     "label": "K-1278",
     "name": "Elegant Satin"
   },
   {
-    "hex": "#eff3e6 ",
+    "hex": "#eff3e6",
     "label": "K-1279",
     "name": "Mint Essence"
   },
   {
-    "hex": "#f5f2e1 ",
+    "hex": "#f5f2e1",
     "label": "K-1280",
     "name": "Little Flower"
   },
   {
-    "hex": "#f4f2e6 ",
+    "hex": "#f4f2e6",
     "label": "K-1281",
     "name": "Pat O'Butter"
   },
   {
-    "hex": "#f5f1e4 ",
+    "hex": "#f5f1e4",
     "label": "K-1282",
     "name": "Angel Cloud"
   },
   {
-    "hex": "#f5f2e4 ",
+    "hex": "#f5f2e4",
     "label": "K-1283",
     "name": "Ivory Turret"
   },
   {
-    "hex": "#f8f3e3 ",
+    "hex": "#f8f3e3",
     "label": "K-1284",
     "name": "Amberling"
   },
   {
-    "hex": "#f9f3e1 ",
+    "hex": "#f9f3e1",
     "label": "K-1285",
     "name": "Almond Sugar"
   },
   {
-    "hex": "#efe8d4 ",
+    "hex": "#efe8d4",
     "label": "K-1286",
     "name": "Amazing Grace"
   },
   {
-    "hex": "#f1e8cd ",
+    "hex": "#f1e8cd",
     "label": "K-1287",
     "name": "Homemade Biscuit"
   },
   {
-    "hex": "#e8dbc3 ",
+    "hex": "#e8dbc3",
     "label": "K-1288",
     "name": "Arizona Heat"
   },
   {
-    "hex": "#eee4cc ",
+    "hex": "#eee4cc",
     "label": "K-1289",
     "name": "Milk Paint"
   },
   {
-    "hex": "#efe7d0 ",
+    "hex": "#efe7d0",
     "label": "K-1290",
     "name": "Lovely Lace"
   },
   {
-    "hex": "#f2ecda ",
+    "hex": "#f2ecda",
     "label": "K-1291",
     "name": "Beige Daze"
   },
   {
-    "hex": "#f3edda ",
+    "hex": "#f3edda",
     "label": "K-1292",
     "name": "Buff Bluff"
   },
   {
-    "hex": "#f3efe1 ",
+    "hex": "#f3efe1",
     "label": "K-1293",
     "name": "It's A Cream"
   },
   {
-    "hex": "#eae3d1 ",
+    "hex": "#eae3d1",
     "label": "K-1294",
     "name": "Dubai Sand"
   },
   {
-    "hex": "#f4eddf ",
+    "hex": "#f4eddf",
     "label": "K-1295",
     "name": "Pebble Bluff"
   },
   {
-    "hex": "#ebe3d6 ",
+    "hex": "#ebe3d6",
     "label": "K-1296",
     "name": "Bare Necessity"
   },
   {
-    "hex": "#f6eee0 ",
+    "hex": "#f6eee0",
     "label": "K-1297",
     "name": "Apricot Blush"
   },
   {
-    "hex": "#faeee5 ",
+    "hex": "#faeee5",
     "label": "K-1298",
     "name": "Pinky"
   },
   {
-    "hex": "#f5f0e4 ",
+    "hex": "#f5f0e4",
     "label": "K-1299",
     "name": "Whitefair"
   },
   {
-    "hex": "#f7efe3 ",
+    "hex": "#f7efe3",
     "label": "K-1300",
     "name": "Sunbleached Shell"
   },
   {
-    "hex": "#f5eee7 ",
+    "hex": "#f5eee7",
     "label": "K-1301",
     "name": "Magic Mica"
   },
   {
-    "hex": "#f7f3e9 ",
+    "hex": "#f7f3e9",
     "label": "K-1302",
     "name": "Champagne Mist"
   },
   {
-    "hex": "#f7f2e8 ",
+    "hex": "#f7f2e8",
     "label": "K-1303",
     "name": "Barely There"
   },
   {
-    "hex": "#f7f1ea ",
+    "hex": "#f7f1ea",
     "label": "K-1304",
     "name": "Victorian Cameo"
   },
   {
-    "hex": "#f7f3eb ",
+    "hex": "#f7f3eb",
     "label": "K-1305",
     "name": "Palace Gown"
   },
   {
-    "hex": "#f3ede2 ",
+    "hex": "#f3ede2",
     "label": "K-1306",
     "name": "Neutral Ground"
   },
   {
-    "hex": "#f5f1e5 ",
+    "hex": "#f5f1e5",
     "label": "K-1307",
     "name": "Sandpiper Place"
   },
   {
-    "hex": "#f1eee2 ",
+    "hex": "#f1eee2",
     "label": "K-1308",
     "name": "Egg White"
   },
   {
-    "hex": "#f7f3e8 ",
+    "hex": "#f7f3e8",
     "label": "K-1309",
     "name": "Pressed Linen"
   },
   {
-    "hex": "#f4f0e5 ",
+    "hex": "#f4f0e5",
     "label": "K-1310",
     "name": "Beige Tower"
   },
   {
-    "hex": "#f7f5ec ",
+    "hex": "#f7f5ec",
     "label": "K-1311",
     "name": "Cream Pie"
   },
   {
-    "hex": "#f1f0e5 ",
+    "hex": "#f1f0e5",
     "label": "K-1312",
     "name": "Pristine Linen"
   },
   {
-    "hex": "#f6f5ea ",
+    "hex": "#f6f5ea",
     "label": "K-1313",
     "name": "Drifted Sand"
   },
   {
-    "hex": "#f7f5eb ",
+    "hex": "#f7f5eb",
     "label": "K-1314",
     "name": "Pale Sisal"
   },
   {
-    "hex": "#f5f2e7 ",
+    "hex": "#f5f2e7",
     "label": "K-1315",
     "name": "Almost Ivory"
   },
   {
-    "hex": "#f1ede3 ",
+    "hex": "#f1ede3",
     "label": "K-1316",
     "name": "Papier Blanc"
   },
   {
-    "hex": "#f0ede3 ",
+    "hex": "#f0ede3",
     "label": "K-1317",
     "name": "White Silence"
   },
   {
-    "hex": "#eae6d9 ",
+    "hex": "#eae6d9",
     "label": "K-1318",
     "name": "Dream Nights"
   },
   {
-    "hex": "#eeeade ",
+    "hex": "#eeeade",
     "label": "K-1319",
     "name": "Soft Sesame"
   }

--- a/json/vista.json
+++ b/json/vista.json
@@ -7325,6602 +7325,6602 @@
     "name": "Vermont Slate"
   },
   {
-    "hex": " #683c68 ",
+    "hex": "#683c68 ",
     "label": "K-0",
     "name": "Iris Impact"
   },
   {
-    "hex": " #b376b3 ",
+    "hex": "#b376b3 ",
     "label": "K-1",
     "name": "Happy Hyacinth"
   },
   {
-    "hex": " #c593c8 ",
+    "hex": "#c593c8 ",
     "label": "K-2",
     "name": "Japanese Lilac"
   },
   {
-    "hex": " #d2a8d4 ",
+    "hex": "#d2a8d4 ",
     "label": "K-3",
     "name": "Very Violet"
   },
   {
-    "hex": " #e8c0e3 ",
+    "hex": "#e8c0e3 ",
     "label": "K-4",
     "name": "Micaela Abril"
   },
   {
-    "hex": " #eed1e9 ",
+    "hex": "#eed1e9 ",
     "label": "K-5",
     "name": "Lilac Lady"
   },
   {
-    "hex": " #f2e1ec ",
+    "hex": "#f2e1ec ",
     "label": "K-6",
     "name": "Purple Peace"
   },
   {
-    "hex": " #f3eeee ",
+    "hex": "#f3eeee ",
     "label": "K-7",
     "name": "Light Lavender"
   },
   {
-    "hex": " #483d4c ",
+    "hex": "#483d4c ",
     "label": "K-8",
     "name": "Midnight Affair"
   },
   {
-    "hex": " #75677f ",
+    "hex": "#75677f ",
     "label": "K-9",
     "name": "Jubilation"
   },
   {
-    "hex": " #8a7c93 ",
+    "hex": "#8a7c93 ",
     "label": "K-10",
     "name": "Pandora's Purple"
   },
   {
-    "hex": " #b0a4b9 ",
+    "hex": "#b0a4b9 ",
     "label": "K-11",
     "name": "Italian Iris"
   },
   {
-    "hex": " #c9b8cb ",
+    "hex": "#c9b8cb ",
     "label": "K-12",
     "name": "Wisteria Wish"
   },
   {
-    "hex": " #d5c7d6 ",
+    "hex": "#d5c7d6 ",
     "label": "K-13",
     "name": "Last of the Lilacs"
   },
   {
-    "hex": " #e3d9e1 ",
+    "hex": "#e3d9e1 ",
     "label": "K-14",
     "name": "Lavender Laugh"
   },
   {
-    "hex": " #efeaeb ",
+    "hex": "#efeaeb ",
     "label": "K-15",
     "name": "Lilac Frost"
   },
   {
-    "hex": " #583f64 ",
+    "hex": "#583f64 ",
     "label": "K-16",
     "name": "Royal Rajah"
   },
   {
-    "hex": " #8c75a2 ",
+    "hex": "#8c75a2 ",
     "label": "K-17",
     "name": "Regal Jewel"
   },
   {
-    "hex": " #a693bc ",
+    "hex": "#a693bc ",
     "label": "K-18",
     "name": "Lilac Garden"
   },
   {
-    "hex": " #c2b0d1 ",
+    "hex": "#c2b0d1 ",
     "label": "K-19",
     "name": "Teresa's True Color"
   },
   {
-    "hex": " #d3c1dd ",
+    "hex": "#d3c1dd ",
     "label": "K-20",
     "name": "Lavender Lilac"
   },
   {
-    "hex": " #e4d9e8 ",
+    "hex": "#e4d9e8 ",
     "label": "K-21",
     "name": "Spring Crocus"
   },
   {
-    "hex": " #ebe3eb ",
+    "hex": "#ebe3eb ",
     "label": "K-22",
     "name": "Pale Pansy"
   },
   {
-    "hex": " #efe9ec ",
+    "hex": "#efe9ec ",
     "label": "K-23",
     "name": "Lilac Lass"
   },
   {
-    "hex": " #583e7b ",
+    "hex": "#583e7b ",
     "label": "K-24",
     "name": "Iris Illusion"
   },
   {
-    "hex": " #8771b2 ",
+    "hex": "#8771b2 ",
     "label": "K-25",
     "name": "Royal Raul"
   },
   {
-    "hex": " #a998cd ",
+    "hex": "#a998cd ",
     "label": "K-26",
     "name": "Lavender Legend"
   },
   {
-    "hex": " #baaad8 ",
+    "hex": "#baaad8 ",
     "label": "K-27",
     "name": "Purple Possibility"
   },
   {
-    "hex": " #d0c0e5 ",
+    "hex": "#d0c0e5 ",
     "label": "K-28",
     "name": "Pansy Potpourri"
   },
   {
-    "hex": " #ddd1eb ",
+    "hex": "#ddd1eb ",
     "label": "K-29",
     "name": "Violetville"
   },
   {
-    "hex": " #e6deee ",
+    "hex": "#e6deee ",
     "label": "K-30",
     "name": "Fancy Pansy"
   },
   {
-    "hex": " #ece7ee ",
+    "hex": "#ece7ee ",
     "label": "K-31",
     "name": "Lavender Splash"
   },
   {
-    "hex": " #4d406b ",
+    "hex": "#4d406b ",
     "label": "K-32",
     "name": "Dark Triumph"
   },
   {
-    "hex": " #8173ab ",
+    "hex": "#8173ab ",
     "label": "K-33",
     "name": "Blooming Lilac"
   },
   {
-    "hex": " #a198c6 ",
+    "hex": "#a198c6 ",
     "label": "K-34",
     "name": "Hermosa"
   },
   {
-    "hex": " #a79fca ",
+    "hex": "#a79fca ",
     "label": "K-35",
     "name": "Gateway to Paradise"
   },
   {
-    "hex": " #bbb3d1 ",
+    "hex": "#bbb3d1 ",
     "label": "K-36",
     "name": "Lilac Lake"
   },
   {
-    "hex": " #cdc3dc ",
+    "hex": "#cdc3dc ",
     "label": "K-37",
     "name": "Evocative Antonia"
   },
   {
-    "hex": " #dbd3e5 ",
+    "hex": "#dbd3e5 ",
     "label": "K-38",
     "name": "Carefree Breeze"
   },
   {
-    "hex": " #ede9ef ",
+    "hex": "#ede9ef ",
     "label": "K-39",
     "name": "Greek Goddess"
   },
   {
-    "hex": " #46404d ",
+    "hex": "#46404d ",
     "label": "K-40",
     "name": "Queen Victoria"
   },
   {
-    "hex": " #6b6678 ",
+    "hex": "#6b6678 ",
     "label": "K-41",
     "name": "Purple Pansies"
   },
   {
-    "hex": " #8d899c ",
+    "hex": "#8d899c ",
     "label": "K-42",
     "name": "Garden Beauty"
   },
   {
-    "hex": " #aba7b7 ",
+    "hex": "#aba7b7 ",
     "label": "K-43",
     "name": "Lap of Luxury"
   },
   {
-    "hex": " #c2b9c7 ",
+    "hex": "#c2b9c7 ",
     "label": "K-44",
     "name": "Hyacinth Haze"
   },
   {
-    "hex": " #d0cad4 ",
+    "hex": "#d0cad4 ",
     "label": "K-45",
     "name": "Shy Violet"
   },
   {
-    "hex": " #ddd8de ",
+    "hex": "#ddd8de ",
     "label": "K-46",
     "name": "Easter Party"
   },
   {
-    "hex": " #eae7e8 ",
+    "hex": "#eae7e8 ",
     "label": "K-47",
     "name": "Lilac Breeze"
   },
   {
-    "hex": " #443e50 ",
+    "hex": "#443e50 ",
     "label": "K-48",
     "name": "Royal Treatment"
   },
   {
-    "hex": " #6b6681 ",
+    "hex": "#6b6681 ",
     "label": "K-49",
     "name": "Vintage Velvet"
   },
   {
-    "hex": " #7c7791 ",
+    "hex": "#7c7791 ",
     "label": "K-50",
     "name": "Suzette"
   },
   {
-    "hex": " #9a96b0 ",
+    "hex": "#9a96b0 ",
     "label": "K-51",
     "name": "Barrymore"
   },
   {
-    "hex": " #a7a4bb ",
+    "hex": "#a7a4bb ",
     "label": "K-52",
     "name": "Luster Blue"
   },
   {
-    "hex": " #c2bbcf ",
+    "hex": "#c2bbcf ",
     "label": "K-53",
     "name": "Province"
   },
   {
-    "hex": " #d5d0dd ",
+    "hex": "#d5d0dd ",
     "label": "K-54",
     "name": "Frosty Glaze"
   },
   {
-    "hex": " #e3dee5 ",
+    "hex": "#e3dee5 ",
     "label": "K-55",
     "name": "Fancy That"
   },
   {
-    "hex": " #4b4169 ",
+    "hex": "#4b4169 ",
     "label": "K-56",
     "name": "Rare Orchid"
   },
   {
-    "hex": " #75709e ",
+    "hex": "#75709e ",
     "label": "K-57",
     "name": "Plum Berry"
   },
   {
-    "hex": " #8481ae ",
+    "hex": "#8481ae ",
     "label": "K-58",
     "name": "Grape Gathering"
   },
   {
-    "hex": " #9794be ",
+    "hex": "#9794be ",
     "label": "K-59",
     "name": "Royal Glimmer"
   },
   {
-    "hex": " #a5a1c9 ",
+    "hex": "#a5a1c9 ",
     "label": "K-60",
     "name": "Lined with Lilacs"
   },
   {
-    "hex": " #ccc8e2 ",
+    "hex": "#ccc8e2 ",
     "label": "K-61",
     "name": "Pick of the Patch"
   },
   {
-    "hex": " #dad7e7 ",
+    "hex": "#dad7e7 ",
     "label": "K-62",
     "name": "Pastel Princess"
   },
   {
-    "hex": " #e4e2ea ",
+    "hex": "#e4e2ea ",
     "label": "K-63",
     "name": "Tentative Dawn"
   },
   {
-    "hex": " #50498a ",
+    "hex": "#50498a ",
     "label": "K-64",
     "name": "Petulant Pat"
   },
   {
-    "hex": " #6d6db1 ",
+    "hex": "#6d6db1 ",
     "label": "K-65",
     "name": "Exotic Beauty"
   },
   {
-    "hex": " #9092cb ",
+    "hex": "#9092cb ",
     "label": "K-66",
     "name": "Adora"
   },
   {
-    "hex": " #aaabda ",
+    "hex": "#aaabda ",
     "label": "K-67",
     "name": "Petal Soft"
   },
   {
-    "hex": " #c0c0e6 ",
+    "hex": "#c0c0e6 ",
     "label": "K-68",
     "name": "Peak of Perfection"
   },
   {
-    "hex": " #cccdea ",
+    "hex": "#cccdea ",
     "label": "K-69",
     "name": "Flora Vista"
   },
   {
-    "hex": " #dbdced ",
+    "hex": "#dbdced ",
     "label": "K-70",
     "name": "Little Cutie"
   },
   {
-    "hex": " #e5e5ee ",
+    "hex": "#e5e5ee ",
     "label": "K-71",
     "name": "Natural Beauty"
   },
   {
-    "hex": " #3e3a74 ",
+    "hex": "#3e3a74 ",
     "label": "K-72",
     "name": "Georgian Court"
   },
   {
-    "hex": " #6a74b7 ",
+    "hex": "#6a74b7 ",
     "label": "K-73",
     "name": "Purple Wave"
   },
   {
-    "hex": " #8692cc ",
+    "hex": "#8692cc ",
     "label": "K-74",
     "name": "Florette"
   },
   {
-    "hex": " #a2a9d9 ",
+    "hex": "#a2a9d9 ",
     "label": "K-75",
     "name": "Roswell"
   },
   {
-    "hex": " #bbc0e6 ",
+    "hex": "#bbc0e6 ",
     "label": "K-76",
     "name": "Berry Blush"
   },
   {
-    "hex": " #d0d4ea ",
+    "hex": "#d0d4ea ",
     "label": "K-77",
     "name": "Beautiful Berry"
   },
   {
-    "hex": " #e4e6ee ",
+    "hex": "#e4e6ee ",
     "label": "K-78",
     "name": "Edge of Dawn"
   },
   {
-    "hex": " #f1f1ef ",
+    "hex": "#f1f1ef ",
     "label": "K-79",
     "name": "Alicia"
   },
   {
-    "hex": " #3b465a ",
+    "hex": "#3b465a ",
     "label": "K-80",
     "name": "Grand Grape"
   },
   {
-    "hex": " #646b8f ",
+    "hex": "#646b8f ",
     "label": "K-81",
     "name": "Mountain Vale"
   },
   {
-    "hex": " #747c9f ",
+    "hex": "#747c9f ",
     "label": "K-82",
     "name": "Premiere Purple"
   },
   {
-    "hex": " #8991b2 ",
+    "hex": "#8991b2 ",
     "label": "K-83",
     "name": "King's Court"
   },
   {
-    "hex": " #a1a6c4 ",
+    "hex": "#a1a6c4 ",
     "label": "K-84",
     "name": "Purple Paradise"
   },
   {
-    "hex": " #babed7 ",
+    "hex": "#babed7 ",
     "label": "K-85",
     "name": "Violet Vista"
   },
   {
-    "hex": " #d4d6e4 ",
+    "hex": "#d4d6e4 ",
     "label": "K-86",
     "name": "Little Grapette"
   },
   {
-    "hex": " #e8e9ec ",
+    "hex": "#e8e9ec ",
     "label": "K-87",
     "name": "Loyalist"
   },
   {
-    "hex": " #3d3f4c ",
+    "hex": "#3d3f4c ",
     "label": "K-88",
     "name": "Pantry Plum"
   },
   {
-    "hex": " #5c6379 ",
+    "hex": "#5c6379 ",
     "label": "K-89",
     "name": "Flirty Fran"
   },
   {
-    "hex": " #7e889f ",
+    "hex": "#7e889f ",
     "label": "K-90",
     "name": "Pale Orchid"
   },
   {
-    "hex": " #9ea6b9 ",
+    "hex": "#9ea6b9 ",
     "label": "K-91",
     "name": "Purpley Puff"
   },
   {
-    "hex": " #b2b9ca ",
+    "hex": "#b2b9ca ",
     "label": "K-92",
     "name": "Favorite Things"
   },
   {
-    "hex": " #c5cad6 ",
+    "hex": "#c5cad6 ",
     "label": "K-93",
     "name": "Kecia"
   },
   {
-    "hex": " #d8dce3 ",
+    "hex": "#d8dce3 ",
     "label": "K-94",
     "name": "Romance in Bloom"
   },
   {
-    "hex": " #e4e6e9 ",
+    "hex": "#e4e6e9 ",
     "label": "K-95",
     "name": "Flower Girl"
   },
   {
-    "hex": " #343c79 ",
+    "hex": "#343c79 ",
     "label": "K-96",
     "name": "Evening Magic"
   },
   {
-    "hex": " #506fb3 ",
+    "hex": "#506fb3 ",
     "label": "K-97",
     "name": "Blue Bounty"
   },
   {
-    "hex": " #7694ce ",
+    "hex": "#7694ce ",
     "label": "K-98",
     "name": "Royal Regatta"
   },
   {
-    "hex": " #98afdc ",
+    "hex": "#98afdc ",
     "label": "K-99",
     "name": "Prince Charming"
   },
   {
-    "hex": " #acc1e6 ",
+    "hex": "#acc1e6 ",
     "label": "K-100",
     "name": "Morning Sky"
   },
   {
-    "hex": " #c8d7ed ",
+    "hex": "#c8d7ed ",
     "label": "K-101",
     "name": "Breezy Blue"
   },
   {
-    "hex": " #dde5ef ",
+    "hex": "#dde5ef ",
     "label": "K-102",
     "name": "Moondancing"
   },
   {
-    "hex": " #edefef ",
+    "hex": "#edefef ",
     "label": "K-103",
     "name": "Icy Blue"
   },
   {
-    "hex": " #254280 ",
+    "hex": "#254280 ",
     "label": "K-104",
     "name": "Evening in Paris"
   },
   {
-    "hex": " #5b79aa ",
+    "hex": "#5b79aa ",
     "label": "K-105",
     "name": "Harbor Blue"
   },
   {
-    "hex": " #7d98c4 ",
+    "hex": "#7d98c4 ",
     "label": "K-106",
     "name": "South Port"
   },
   {
-    "hex": " #98afd3 ",
+    "hex": "#98afd3 ",
     "label": "K-107",
     "name": "Washed Indigo"
   },
   {
-    "hex": " #a7bdde ",
+    "hex": "#a7bdde ",
     "label": "K-108",
     "name": "Scuba Blue"
   },
   {
-    "hex": " #b4c7e2 ",
+    "hex": "#b4c7e2 ",
     "label": "K-109",
     "name": "By the Bay"
   },
   {
-    "hex": " #cad6e8 ",
+    "hex": "#cad6e8 ",
     "label": "K-110",
     "name": "Blue Dawn"
   },
   {
-    "hex": " #e3e7ea ",
+    "hex": "#e3e7ea ",
     "label": "K-111",
     "name": "Blue Brush Stroke"
   },
   {
-    "hex": " #30405a ",
+    "hex": "#30405a ",
     "label": "K-112",
     "name": "Night on the Town"
   },
   {
-    "hex": " #476a8f ",
+    "hex": "#476a8f ",
     "label": "K-113",
     "name": "Blue Monday"
   },
   {
-    "hex": " #6e91b3 ",
+    "hex": "#6e91b3 ",
     "label": "K-114",
     "name": "Postcard Perfect"
   },
   {
-    "hex": " #86a4c2 ",
+    "hex": "#86a4c2 ",
     "label": "K-115",
     "name": "Far Horizons"
   },
   {
-    "hex": " #a4bfd9 ",
+    "hex": "#a4bfd9 ",
     "label": "K-116",
     "name": "Blissful Blue"
   },
   {
-    "hex": " #b9cfe1 ",
+    "hex": "#b9cfe1 ",
     "label": "K-117",
     "name": "Sail Away"
   },
   {
-    "hex": " #cbdbe7 ",
+    "hex": "#cbdbe7 ",
     "label": "K-118",
     "name": "Summer Sky"
   },
   {
-    "hex": " #e5eced ",
+    "hex": "#e5eced ",
     "label": "K-119",
     "name": "Jet Stream"
   },
   {
-    "hex": " #34435b ",
+    "hex": "#34435b ",
     "label": "K-120",
     "name": "Blue Moon Bay"
   },
   {
-    "hex": " #4c6b8b ",
+    "hex": "#4c6b8b ",
     "label": "K-121",
     "name": "Pleasant Lake"
   },
   {
-    "hex": " #587797 ",
+    "hex": "#587797 ",
     "label": "K-122",
     "name": "Sea of Marma"
   },
   {
-    "hex": " #6b8aa9 ",
+    "hex": "#6b8aa9 ",
     "label": "K-123",
     "name": "Piece of the Sky"
   },
   {
-    "hex": " #91acc4 ",
+    "hex": "#91acc4 ",
     "label": "K-124",
     "name": "Beecher Falls"
   },
   {
-    "hex": " #aec6da ",
+    "hex": "#aec6da ",
     "label": "K-125",
     "name": "Quiet Refuge"
   },
   {
-    "hex": " #cbdae5 ",
+    "hex": "#cbdae5 ",
     "label": "K-126",
     "name": "Precious Dew Drop"
   },
   {
-    "hex": " #e1e8ea ",
+    "hex": "#e1e8ea ",
     "label": "K-127",
     "name": "June Breeze"
   },
   {
-    "hex": " #224b8f ",
+    "hex": "#224b8f ",
     "label": "K-128",
     "name": "Cascade Twilight"
   },
   {
-    "hex": " #297bc1 ",
+    "hex": "#297bc1 ",
     "label": "K-129",
     "name": "Soothing Sapphire"
   },
   {
-    "hex": " #569ad7 ",
+    "hex": "#569ad7 ",
     "label": "K-130",
     "name": "Breathtaking Blue"
   },
   {
-    "hex": " #6ca8de ",
+    "hex": "#6ca8de ",
     "label": "K-131",
     "name": "City of Atlantis"
   },
   {
-    "hex": " #8ec1e9 ",
+    "hex": "#8ec1e9 ",
     "label": "K-132",
     "name": "Blue Sky"
   },
   {
-    "hex": " #abd1ee ",
+    "hex": "#abd1ee ",
     "label": "K-133",
     "name": "Young Boy Blue"
   },
   {
-    "hex": " #c8e0ef ",
+    "hex": "#c8e0ef ",
     "label": "K-134",
     "name": "Prairie Day"
   },
   {
-    "hex": " #e4eeef ",
+    "hex": "#e4eeef ",
     "label": "K-135",
     "name": "Calypso Breeze"
   },
   {
-    "hex": " #244667 ",
+    "hex": "#244667 ",
     "label": "K-136",
     "name": "Prairie Night"
   },
   {
-    "hex": " #3e7da8 ",
+    "hex": "#3e7da8 ",
     "label": "K-137",
     "name": "Wakeby Beach"
   },
   {
-    "hex": " #6198c0 ",
+    "hex": "#6198c0 ",
     "label": "K-138",
     "name": "Bird's Egg Blue"
   },
   {
-    "hex": " #87b4d4 ",
+    "hex": "#87b4d4 ",
     "label": "K-139",
     "name": "Gaugin's Blue"
   },
   {
-    "hex": " #98c2df ",
+    "hex": "#98c2df ",
     "label": "K-140",
     "name": "Make a Splash"
   },
   {
-    "hex": " #bbd7e7 ",
+    "hex": "#bbd7e7 ",
     "label": "K-141",
     "name": "Blooming Blue"
   },
   {
-    "hex": " #d7e6ec ",
+    "hex": "#d7e6ec ",
     "label": "K-142",
     "name": "Bird Bath Blue"
   },
   {
-    "hex": " #e2edee ",
+    "hex": "#e2edee ",
     "label": "K-143",
     "name": "Spring Dew"
   },
   {
-    "hex": " #064f77 ",
+    "hex": "#064f77 ",
     "label": "K-144",
     "name": "Blue By You"
   },
   {
-    "hex": " #1a84b2 ",
+    "hex": "#1a84b2 ",
     "label": "K-145",
     "name": "Hidden Springs"
   },
   {
-    "hex": " #4a9cc7 ",
+    "hex": "#4a9cc7 ",
     "label": "K-146",
     "name": "Bonaventure"
   },
   {
-    "hex": " #7bb8d9 ",
+    "hex": "#7bb8d9 ",
     "label": "K-147",
     "name": "Cascade Blue"
   },
   {
-    "hex": " #86c3e4 ",
+    "hex": "#86c3e4 ",
     "label": "K-148",
     "name": "Lupe's Lake"
   },
   {
-    "hex": " #a6d3e9 ",
+    "hex": "#a6d3e9 ",
     "label": "K-149",
     "name": "Sky Watch"
   },
   {
-    "hex": " #c9e4ee ",
+    "hex": "#c9e4ee ",
     "label": "K-150",
     "name": "High Spirits"
   },
   {
-    "hex": " #daebef ",
+    "hex": "#daebef ",
     "label": "K-151",
     "name": "Dreamy Space"
   },
   {
-    "hex": " #243a52 ",
+    "hex": "#243a52 ",
     "label": "K-152",
     "name": "Blazer Blue"
   },
   {
-    "hex": " #40677e ",
+    "hex": "#40677e ",
     "label": "K-153",
     "name": "Blue Suede Shoes"
   },
   {
-    "hex": " #618aa3 ",
+    "hex": "#618aa3 ",
     "label": "K-154",
     "name": "Storm Blue Sky"
   },
   {
-    "hex": " #7ba0b7 ",
+    "hex": "#7ba0b7 ",
     "label": "K-155",
     "name": "Thunder Bay"
   },
   {
-    "hex": " #95bbcf ",
+    "hex": "#95bbcf ",
     "label": "K-156",
     "name": "Dresden Falls"
   },
   {
-    "hex": " #a3c4d6 ",
+    "hex": "#a3c4d6 ",
     "label": "K-157",
     "name": "Oh Boy!"
   },
   {
-    "hex": " #bad2df ",
+    "hex": "#bad2df ",
     "label": "K-158",
     "name": "Swirling Water"
   },
   {
-    "hex": " #dbe7ea ",
+    "hex": "#dbe7ea ",
     "label": "K-159",
     "name": "Phantom Lake"
   },
   {
-    "hex": " #303d44 ",
+    "hex": "#303d44 ",
     "label": "K-160",
     "name": "Puerto Deseado"
   },
   {
-    "hex": " #506f7b ",
+    "hex": "#506f7b ",
     "label": "K-161",
     "name": "Dusk Blue"
   },
   {
-    "hex": " #7493a0 ",
+    "hex": "#7493a0 ",
     "label": "K-162",
     "name": "Breezy Indigo"
   },
   {
-    "hex": " #94afba ",
+    "hex": "#94afba ",
     "label": "K-163",
     "name": "Maracay Bay"
   },
   {
-    "hex": " #a7c0c9 ",
+    "hex": "#a7c0c9 ",
     "label": "K-164",
     "name": "Exotic Port"
   },
   {
-    "hex": " #b8d0d7 ",
+    "hex": "#b8d0d7 ",
     "label": "K-165",
     "name": "Hatteras Haze"
   },
   {
-    "hex": " #c9dade ",
+    "hex": "#c9dade ",
     "label": "K-166",
     "name": "Sierra Spring"
   },
   {
-    "hex": " #dee8e8 ",
+    "hex": "#dee8e8 ",
     "label": "K-167",
     "name": "Cloud-wisped Sky"
   },
   {
-    "hex": " #00547b ",
+    "hex": "#00547b ",
     "label": "K-168",
     "name": "Citadel Blue"
   },
   {
-    "hex": " #008eb8 ",
+    "hex": "#008eb8 ",
     "label": "K-169",
     "name": "Old Port"
   },
   {
-    "hex": " #26a5cb ",
+    "hex": "#26a5cb ",
     "label": "K-170",
     "name": "True Sky Blue"
   },
   {
-    "hex": " #56b5d6 ",
+    "hex": "#56b5d6 ",
     "label": "K-171",
     "name": "Sunrise River"
   },
   {
-    "hex": " #7bc9e4 ",
+    "hex": "#7bc9e4 ",
     "label": "K-172",
     "name": "Paradise Bay"
   },
   {
-    "hex": " #9fd7e9 ",
+    "hex": "#9fd7e9 ",
     "label": "K-173",
     "name": "New Day Sky"
   },
   {
-    "hex": " #c5e6ed ",
+    "hex": "#c5e6ed ",
     "label": "K-174",
     "name": "Simply Heaven "
   },
   {
-    "hex": " #e0eeed ",
+    "hex": "#e0eeed ",
     "label": "K-175",
     "name": "Whispery Breeze"
   },
   {
-    "hex": " #34545e ",
+    "hex": "#34545e ",
     "label": "K-176",
     "name": "Under the Sea"
   },
   {
-    "hex": " #497786 ",
+    "hex": "#497786 ",
     "label": "K-177",
     "name": "Ocean Blues"
   },
   {
-    "hex": " #6d99a9 ",
+    "hex": "#6d99a9 ",
     "label": "K-178",
     "name": "Wonderful World"
   },
   {
-    "hex": " #93b6c3 ",
+    "hex": "#93b6c3 ",
     "label": "K-179",
     "name": "Tropical Sea"
   },
   {
-    "hex": " #a2c5d0 ",
+    "hex": "#a2c5d0 ",
     "label": "K-180",
     "name": "Gift of the Sea"
   },
   {
-    "hex": " #b9d4db ",
+    "hex": "#b9d4db ",
     "label": "K-181",
     "name": "Seaside Pleasure"
   },
   {
-    "hex": " #d6e4e5 ",
+    "hex": "#d6e4e5 ",
     "label": "K-182",
     "name": "Caribbean Sky"
   },
   {
-    "hex": " #eaefec ",
+    "hex": "#eaefec ",
     "label": "K-183",
     "name": "Fair Winds"
   },
   {
-    "hex": " #1b485d ",
+    "hex": "#1b485d ",
     "label": "K-184",
     "name": "Night Edition"
   },
   {
-    "hex": " #0089a6 ",
+    "hex": "#0089a6 ",
     "label": "K-185",
     "name": "Puerto Mio"
   },
   {
-    "hex": " #4caac4 ",
+    "hex": "#4caac4 ",
     "label": "K-186",
     "name": "Patch of Blue"
   },
   {
-    "hex": " #76bed3 ",
+    "hex": "#76bed3 ",
     "label": "K-187",
     "name": "Skyway"
   },
   {
-    "hex": " #8acdde ",
+    "hex": "#8acdde ",
     "label": "K-188",
     "name": "Joyful Morning"
   },
   {
-    "hex": " #a7d9e6 ",
+    "hex": "#a7d9e6 ",
     "label": "K-189",
     "name": "Walking on Air"
   },
   {
-    "hex": " #bfe3e9 ",
+    "hex": "#bfe3e9 ",
     "label": "K-190",
     "name": "Bright Vision"
   },
   {
-    "hex": " #d1e9ec ",
+    "hex": "#d1e9ec ",
     "label": "K-191",
     "name": "Gypsy Wind"
   },
   {
-    "hex": " #005c7b ",
+    "hex": "#005c7b ",
     "label": "K-192",
     "name": "Sea of Midnight"
   },
   {
-    "hex": " #0094aa ",
+    "hex": "#0094aa ",
     "label": "K-193",
     "name": "Navajo Turquoise"
   },
   {
-    "hex": " #1cadc2 ",
+    "hex": "#1cadc2 ",
     "label": "K-194",
     "name": "Bountiful Blue"
   },
   {
-    "hex": " #6ac5d5 ",
+    "hex": "#6ac5d5 ",
     "label": "K-195",
     "name": "Swan Lake"
   },
   {
-    "hex": " #7cd0de ",
+    "hex": "#7cd0de ",
     "label": "K-196",
     "name": "Ocean Park"
   },
   {
-    "hex": " #9cdbe4 ",
+    "hex": "#9cdbe4 ",
     "label": "K-197",
     "name": "Fantasy Flight"
   },
   {
-    "hex": " #c6e9ec ",
+    "hex": "#c6e9ec ",
     "label": "K-198",
     "name": "Inner Peace"
   },
   {
-    "hex": " #e1f1ee ",
+    "hex": "#e1f1ee ",
     "label": "K-199",
     "name": "Odessa"
   },
   {
-    "hex": " #006067 ",
+    "hex": "#006067 ",
     "label": "K-200",
     "name": "Caribbean Dream"
   },
   {
-    "hex": " #088e95 ",
+    "hex": "#088e95 ",
     "label": "K-201",
     "name": "Aqua Marine"
   },
   {
-    "hex": " #4aa9b2 ",
+    "hex": "#4aa9b2 ",
     "label": "K-202",
     "name": "Brookside"
   },
   {
-    "hex": " #7ac3ca ",
+    "hex": "#7ac3ca ",
     "label": "K-203",
     "name": "Aquavit"
   },
   {
-    "hex": " #8bd1d6 ",
+    "hex": "#8bd1d6 ",
     "label": "K-204",
     "name": "Pleasant View"
   },
   {
-    "hex": " #a7dddf ",
+    "hex": "#a7dddf ",
     "label": "K-205",
     "name": "Christopher Coast"
   },
   {
-    "hex": " #bfe5e5 ",
+    "hex": "#bfe5e5 ",
     "label": "K-206",
     "name": "Swim Team"
   },
   {
-    "hex": " #d1ebea ",
+    "hex": "#d1ebea ",
     "label": "K-207",
     "name": "Crystal River"
   },
   {
-    "hex": " #254b50 ",
+    "hex": "#254b50 ",
     "label": "K-208",
     "name": "Green Mountain Falls"
   },
   {
-    "hex": " #38757b ",
+    "hex": "#38757b ",
     "label": "K-209",
     "name": "Time for Teal"
   },
   {
-    "hex": " #629ca3 ",
+    "hex": "#629ca3 ",
     "label": "K-210",
     "name": "Teal Lake"
   },
   {
-    "hex": " #7fb0b6 ",
+    "hex": "#7fb0b6 ",
     "label": "K-211",
     "name": "Turquoise Trick"
   },
   {
-    "hex": " #93c6c9 ",
+    "hex": "#93c6c9 ",
     "label": "K-212",
     "name": "Coastal View"
   },
   {
-    "hex": " #bcdede ",
+    "hex": "#bcdede ",
     "label": "K-213",
     "name": "Aegean Accent"
   },
   {
-    "hex": " #d0e7e4 ",
+    "hex": "#d0e7e4 ",
     "label": "K-214",
     "name": "Essence of the Sea"
   },
   {
-    "hex": " #ddede9 ",
+    "hex": "#ddede9 ",
     "label": "K-215",
     "name": "Bay Breeze"
   },
   {
-    "hex": " #204749 ",
+    "hex": "#204749 ",
     "label": "K-216",
     "name": "Woodland Springs"
   },
   {
-    "hex": " #4c7474 ",
+    "hex": "#4c7474 ",
     "label": "K-217",
     "name": "Mandalay Bay"
   },
   {
-    "hex": " #6b9597 ",
+    "hex": "#6b9597 ",
     "label": "K-218",
     "name": "Teal Tease"
   },
   {
-    "hex": " #82a9aa ",
+    "hex": "#82a9aa ",
     "label": "K-219",
     "name": "Acapulco Aqua"
   },
   {
-    "hex": " #9ec6c3 ",
+    "hex": "#9ec6c3 ",
     "label": "K-220",
     "name": "Teal Twilight"
   },
   {
-    "hex": " #b6d5d1 ",
+    "hex": "#b6d5d1 ",
     "label": "K-221",
     "name": "Seaside Accents"
   },
   {
-    "hex": " #c9e0dd ",
+    "hex": "#c9e0dd ",
     "label": "K-222",
     "name": "Iced Teal"
   },
   {
-    "hex": " #e2eae6 ",
+    "hex": "#e2eae6 ",
     "label": "K-223",
     "name": "Bay Cruise"
   },
   {
-    "hex": " #0e535a ",
+    "hex": "#0e535a ",
     "label": "K-224",
     "name": "Mountain Mist"
   },
   {
-    "hex": " #3c8583 ",
+    "hex": "#3c8583 ",
     "label": "K-225",
     "name": "Tropical Teal"
   },
   {
-    "hex": " #5b9e9b ",
+    "hex": "#5b9e9b ",
     "label": "K-226",
     "name": "Peaceful Pond"
   },
   {
-    "hex": " #92c4c3 ",
+    "hex": "#92c4c3 ",
     "label": "K-227",
     "name": "Kentucky Estate"
   },
   {
-    "hex": " #a2d2d0 ",
+    "hex": "#a2d2d0 ",
     "label": "K-228",
     "name": "Fair Farmington"
   },
   {
-    "hex": " #badfdb ",
+    "hex": "#badfdb ",
     "label": "K-229",
     "name": "Nature's Theme"
   },
   {
-    "hex": " #dcece8 ",
+    "hex": "#dcece8 ",
     "label": "K-230",
     "name": "Blue Green Gem"
   },
   {
-    "hex": " #e6f1ec ",
+    "hex": "#e6f1ec ",
     "label": "K-231",
     "name": "Meadow Mist"
   },
   {
-    "hex": " #006668 ",
+    "hex": "#006668 ",
     "label": "K-232",
     "name": "Turquoise Trinket"
   },
   {
-    "hex": " #00a2a0 ",
+    "hex": "#00a2a0 ",
     "label": "K-233",
     "name": "Soothing Song"
   },
   {
-    "hex": " #06b8b9 ",
+    "hex": "#06b8b9 ",
     "label": "K-234",
     "name": "Cool Turquoise"
   },
   {
-    "hex": " #6bcecf ",
+    "hex": "#6bcecf ",
     "label": "K-235",
     "name": "Oceanside Paradise"
   },
   {
-    "hex": " #7fdad9 ",
+    "hex": "#7fdad9 ",
     "label": "K-236",
     "name": "Turquoise Treat"
   },
   {
-    "hex": " #a5e4e2 ",
+    "hex": "#a5e4e2 ",
     "label": "K-237",
     "name": "Aqua Infusion"
   },
   {
-    "hex": " #bfeae6 ",
+    "hex": "#bfeae6 ",
     "label": "K-238",
     "name": "Baby Aqua"
   },
   {
-    "hex": " #d1efea ",
+    "hex": "#d1efea ",
     "label": "K-239",
     "name": "Tender Touch"
   },
   {
-    "hex": " #006d5f ",
+    "hex": "#006d5f ",
     "label": "K-240",
     "name": "Emerald Accent"
   },
   {
-    "hex": " #00a79d ",
+    "hex": "#00a79d ",
     "label": "K-241",
     "name": "So Jaded"
   },
   {
-    "hex": " #00bcb5 ",
+    "hex": "#00bcb5 ",
     "label": "K-242",
     "name": "Alexandra Valley"
   },
   {
-    "hex": " #5bcdc7 ",
+    "hex": "#5bcdc7 ",
     "label": "K-243",
     "name": "May Day"
   },
   {
-    "hex": " #7ddbd4 ",
+    "hex": "#7ddbd4 ",
     "label": "K-244",
     "name": "Glorious Garden"
   },
   {
-    "hex": " #a4e6e0 ",
+    "hex": "#a4e6e0 ",
     "label": "K-245",
     "name": "Aged Aegean"
   },
   {
-    "hex": " #bfede6 ",
+    "hex": "#bfede6 ",
     "label": "K-246",
     "name": "Harington"
   },
   {
-    "hex": " #d0f0e9 ",
+    "hex": "#d0f0e9 ",
     "label": "K-247",
     "name": "Spa Springs"
   },
   {
-    "hex": " #006059 ",
+    "hex": "#006059 ",
     "label": "K-248",
     "name": "Enchanted Evergreen"
   },
   {
-    "hex": " #2d8e84 ",
+    "hex": "#2d8e84 ",
     "label": "K-249",
     "name": "Time to Grow"
   },
   {
-    "hex": " #5aada6 ",
+    "hex": "#5aada6 ",
     "label": "K-250",
     "name": "Picnic Haven"
   },
   {
-    "hex": " #7fc2bb ",
+    "hex": "#7fc2bb ",
     "label": "K-251",
     "name": "Meadow Green"
   },
   {
-    "hex": " #9cd9d0 ",
+    "hex": "#9cd9d0 ",
     "label": "K-252",
     "name": "Kylemore"
   },
   {
-    "hex": " #a8dfd6 ",
+    "hex": "#a8dfd6 ",
     "label": "K-253",
     "name": "Mild Mallard"
   },
   {
-    "hex": " #c0e7e0 ",
+    "hex": "#c0e7e0 ",
     "label": "K-254",
     "name": "Prairie Princess"
   },
   {
-    "hex": " #d1ede6 ",
+    "hex": "#d1ede6 ",
     "label": "K-255",
     "name": "Glorianna"
   },
   {
-    "hex": " #174e46 ",
+    "hex": "#174e46 ",
     "label": "K-256",
     "name": "Country Meadow"
   },
   {
-    "hex": " #3b8272 ",
+    "hex": "#3b8272 ",
     "label": "K-257",
     "name": "Emerald Valley"
   },
   {
-    "hex": " #62a699 ",
+    "hex": "#62a699 ",
     "label": "K-258",
     "name": "Aged Jade"
   },
   {
-    "hex": " #82bdb1 ",
+    "hex": "#82bdb1 ",
     "label": "K-259",
     "name": "Green Grace"
   },
   {
-    "hex": " #96d0c3 ",
+    "hex": "#96d0c3 ",
     "label": "K-260",
     "name": "Kodiak Valley"
   },
   {
-    "hex": " #addbcf ",
+    "hex": "#addbcf ",
     "label": "K-261",
     "name": "Irish Lass"
   },
   {
-    "hex": " #bfe4da ",
+    "hex": "#bfe4da ",
     "label": "K-262",
     "name": "Summer's Secret"
   },
   {
-    "hex": " #d0ebe2 ",
+    "hex": "#d0ebe2 ",
     "label": "K-263",
     "name": "Mystic Glow"
   },
   {
-    "hex": " #007057 ",
+    "hex": "#007057 ",
     "label": "K-264",
     "name": "Shamrock Green"
   },
   {
-    "hex": " #00a283 ",
+    "hex": "#00a283 ",
     "label": "K-265",
     "name": "Emerald Acres"
   },
   {
-    "hex": " #55c0a9 ",
+    "hex": "#55c0a9 ",
     "label": "K-266",
     "name": "Jolt of Jade"
   },
   {
-    "hex": " #75ceba ",
+    "hex": "#75ceba ",
     "label": "K-267",
     "name": "My Garden Party"
   },
   {
-    "hex": " #87dbc7 ",
+    "hex": "#87dbc7 ",
     "label": "K-268",
     "name": "Irish Isle"
   },
   {
-    "hex": " #a8e7d7 ",
+    "hex": "#a8e7d7 ",
     "label": "K-269",
     "name": "Jardin Jewel"
   },
   {
-    "hex": " #c6ecde ",
+    "hex": "#c6ecde ",
     "label": "K-270",
     "name": "Teal Twist"
   },
   {
-    "hex": " #e2f1e6 ",
+    "hex": "#e2f1e6 ",
     "label": "K-271",
     "name": "Garden Sprite"
   },
   {
-    "hex": " #2a574c ",
+    "hex": "#2a574c ",
     "label": "K-272",
     "name": "Woodland Fern"
   },
   {
-    "hex": " #49866e ",
+    "hex": "#49866e ",
     "label": "K-273",
     "name": "Jasmine Jazz"
   },
   {
-    "hex": " #6ca793 ",
+    "hex": "#6ca793 ",
     "label": "K-274",
     "name": "Gardening Girl"
   },
   {
-    "hex": " #86bba8 ",
+    "hex": "#86bba8 ",
     "label": "K-275",
     "name": "Laurel Village"
   },
   {
-    "hex": " #9fd3bf ",
+    "hex": "#9fd3bf ",
     "label": "K-276",
     "name": "Fantasy Isle"
   },
   {
-    "hex": " #b5decd ",
+    "hex": "#b5decd ",
     "label": "K-277",
     "name": "Mermaid Magic"
   },
   {
-    "hex": " #d2eadd ",
+    "hex": "#d2eadd ",
     "label": "K-278",
     "name": "Spring Folly"
   },
   {
-    "hex": " #dceee4 ",
+    "hex": "#dceee4 ",
     "label": "K-279",
     "name": "Song of Summer"
   },
   {
-    "hex": " #008b56 ",
+    "hex": "#008b56 ",
     "label": "K-280",
     "name": "Center Field"
   },
   {
-    "hex": " #00b080 ",
+    "hex": "#00b080 ",
     "label": "K-281",
     "name": "Peaceful Thyme"
   },
   {
-    "hex": " #49c49c ",
+    "hex": "#49c49c ",
     "label": "K-282",
     "name": "Day in the Garden"
   },
   {
-    "hex": " #7ed8b9 ",
+    "hex": "#7ed8b9 ",
     "label": "K-283",
     "name": "Esmerelda"
   },
   {
-    "hex": " #91e3c9 ",
+    "hex": "#91e3c9 ",
     "label": "K-284",
     "name": "Summer Sonata"
   },
   {
-    "hex": " #abead5 ",
+    "hex": "#abead5 ",
     "label": "K-285",
     "name": "Glen Haven"
   },
   {
-    "hex": " #d3f0e4 ",
+    "hex": "#d3f0e4 ",
     "label": "K-286",
     "name": "Garden Soft Green"
   },
   {
-    "hex": " #e5f2e9 ",
+    "hex": "#e5f2e9 ",
     "label": "K-287",
     "name": "Spring Splendor"
   },
   {
-    "hex": " #236843 ",
+    "hex": "#236843 ",
     "label": "K-288",
     "name": "The Back Nine"
   },
   {
-    "hex": " #598f71 ",
+    "hex": "#598f71 ",
     "label": "K-289",
     "name": "Garden Leaf"
   },
   {
-    "hex": " #6da489 ",
+    "hex": "#6da489 ",
     "label": "K-290",
     "name": "Tarragon Tease"
   },
   {
-    "hex": " #91c0a9 ",
+    "hex": "#91c0a9 ",
     "label": "K-291",
     "name": "Pioneer Park"
   },
   {
-    "hex": " #a9d6bf ",
+    "hex": "#a9d6bf ",
     "label": "K-292",
     "name": "Garden Greenery"
   },
   {
-    "hex": " #c2e3d1 ",
+    "hex": "#c2e3d1 ",
     "label": "K-293",
     "name": "Spring Meadow"
   },
   {
-    "hex": " #d3eadb ",
+    "hex": "#d3eadb ",
     "label": "K-294",
     "name": "Island Spirit"
   },
   {
-    "hex": " #def0e4 ",
+    "hex": "#def0e4 ",
     "label": "K-295",
     "name": "Dream of Green"
   },
   {
-    "hex": " #1f7d43 ",
+    "hex": "#1f7d43 ",
     "label": "K-296",
     "name": "Forever Green"
   },
   {
-    "hex": " #48a469 ",
+    "hex": "#48a469 ",
     "label": "K-297",
     "name": "Summer Sumac"
   },
   {
-    "hex": " #66bb8a ",
+    "hex": "#66bb8a ",
     "label": "K-298",
     "name": "Garden Variety"
   },
   {
-    "hex": " #8dd0a9 ",
+    "hex": "#8dd0a9 ",
     "label": "K-299",
     "name": "Sage Brush Place"
   },
   {
-    "hex": " #9de0bd ",
+    "hex": "#9de0bd ",
     "label": "K-300",
     "name": "Green Pastures"
   },
   {
-    "hex": " #b0e5c9 ",
+    "hex": "#b0e5c9 ",
     "label": "K-301",
     "name": "Phillip's Field"
   },
   {
-    "hex": " #cfeeda ",
+    "hex": "#cfeeda ",
     "label": "K-302",
     "name": "Subtle Splendor"
   },
   {
-    "hex": " #e1f1e4 ",
+    "hex": "#e1f1e4 ",
     "label": "K-303",
     "name": "Rites of Spring"
   },
   {
-    "hex": " #4c6c4c ",
+    "hex": "#4c6c4c ",
     "label": "K-304",
     "name": "Tall Timber"
   },
   {
-    "hex": " #658e6c ",
+    "hex": "#658e6c ",
     "label": "K-305",
     "name": "Woodland Sage"
   },
   {
-    "hex": " #82a98c ",
+    "hex": "#82a98c ",
     "label": "K-306",
     "name": "Lakeside Pine"
   },
   {
-    "hex": " #9fc3a9 ",
+    "hex": "#9fc3a9 ",
     "label": "K-307",
     "name": "Aged Sage"
   },
   {
-    "hex": " #b2d4ba ",
+    "hex": "#b2d4ba ",
     "label": "K-308",
     "name": "Pinetree Trail"
   },
   {
-    "hex": " #c9e2ce ",
+    "hex": "#c9e2ce ",
     "label": "K-309",
     "name": "Whisper of Pine"
   },
   {
-    "hex": " #d8e9d9 ",
+    "hex": "#d8e9d9 ",
     "label": "K-310",
     "name": "Welcome Spring"
   },
   {
-    "hex": " #e3efe2 ",
+    "hex": "#e3efe2 ",
     "label": "K-311",
     "name": "Soft Mint"
   },
   {
-    "hex": " #2aa238 ",
+    "hex": "#2aa238 ",
     "label": "K-312",
     "name": "Jolly Holly"
   },
   {
-    "hex": " #69c365 ",
+    "hex": "#69c365 ",
     "label": "K-313",
     "name": "Elmvale"
   },
   {
-    "hex": " #8bd385 ",
+    "hex": "#8bd385 ",
     "label": "K-314",
     "name": "Amazon Trail"
   },
   {
-    "hex": " #aee2a8 ",
+    "hex": "#aee2a8 ",
     "label": "K-315",
     "name": "Wild Weeds"
   },
   {
-    "hex": " #bde9b9 ",
+    "hex": "#bde9b9 ",
     "label": "K-316",
     "name": "Althorp Park"
   },
   {
-    "hex": " #d1efc9 ",
+    "hex": "#d1efc9 ",
     "label": "K-317",
     "name": "Spring Leaves"
   },
   {
-    "hex": " #e2f2db ",
+    "hex": "#e2f2db ",
     "label": "K-318",
     "name": "Flowing Green"
   },
   {
-    "hex": " #e9f3e2 ",
+    "hex": "#e9f3e2 ",
     "label": "K-319",
     "name": "Prelude to Summer"
   },
   {
-    "hex": " #5ab32c ",
+    "hex": "#5ab32c ",
     "label": "K-320",
     "name": "Wilderness Retreat"
   },
   {
-    "hex": " #87cb61 ",
+    "hex": "#87cb61 ",
     "label": "K-321",
     "name": "Hidden Hills"
   },
   {
-    "hex": " #a0dc85 ",
+    "hex": "#a0dc85 ",
     "label": "K-322",
     "name": "Frog Prince"
   },
   {
-    "hex": " #bce5a1 ",
+    "hex": "#bce5a1 ",
     "label": "K-323",
     "name": "Sage Sensation"
   },
   {
-    "hex": " #cbecb5 ",
+    "hex": "#cbecb5 ",
     "label": "K-324",
     "name": "Green Light"
   },
   {
-    "hex": " #e4f2d2 ",
+    "hex": "#e4f2d2 ",
     "label": "K-325",
     "name": "Grassy Path"
   },
   {
-    "hex": " #ebf3db ",
+    "hex": "#ebf3db ",
     "label": "K-326",
     "name": "Spring Sonnet"
   },
   {
-    "hex": " #f0f4e4 ",
+    "hex": "#f0f4e4 ",
     "label": "K-327",
     "name": "Misty Meadow"
   },
   {
-    "hex": " #5e903e ",
+    "hex": "#5e903e ",
     "label": "K-328",
     "name": "Lily Pad Place"
   },
   {
-    "hex": " #80b063 ",
+    "hex": "#80b063 ",
     "label": "K-329",
     "name": "Green Jeans"
   },
   {
-    "hex": " #96c383 ",
+    "hex": "#96c383 ",
     "label": "K-330",
     "name": "Grand Valley"
   },
   {
-    "hex": " #b8d8a4 ",
+    "hex": "#b8d8a4 ",
     "label": "K-331",
     "name": "Garden Stroll"
   },
   {
-    "hex": " #c4e3b5 ",
+    "hex": "#c4e3b5 ",
     "label": "K-332",
     "name": "Lincoln Park"
   },
   {
-    "hex": " #d4ebc7 ",
+    "hex": "#d4ebc7 ",
     "label": "K-333",
     "name": "Echo of Spring"
   },
   {
-    "hex": " #e5f1da ",
+    "hex": "#e5f1da ",
     "label": "K-334",
     "name": "Budding Leaf"
   },
   {
-    "hex": " #eaf2e1 ",
+    "hex": "#eaf2e1 ",
     "label": "K-335",
     "name": "Green Republic"
   },
   {
-    "hex": " #537640 ",
+    "hex": "#537640 ",
     "label": "K-336",
     "name": "Dark Drama"
   },
   {
-    "hex": " #789963 ",
+    "hex": "#789963 ",
     "label": "K-337",
     "name": "Jungle Birds"
   },
   {
-    "hex": " #9ab78b ",
+    "hex": "#9ab78b ",
     "label": "K-338",
     "name": "Little Green Frog"
   },
   {
-    "hex": " #b8cfac ",
+    "hex": "#b8cfac ",
     "label": "K-339",
     "name": "Quiet Kiwi"
   },
   {
-    "hex": " #c9ddbd ",
+    "hex": "#c9ddbd ",
     "label": "K-340",
     "name": "East of Eden"
   },
   {
-    "hex": " #d5e6cb ",
+    "hex": "#d5e6cb ",
     "label": "K-341",
     "name": "Springfield"
   },
   {
-    "hex": " #e1edd8 ",
+    "hex": "#e1edd8 ",
     "label": "K-342",
     "name": "Nature's Palette"
   },
   {
-    "hex": " #e9f0e0 ",
+    "hex": "#e9f0e0 ",
     "label": "K-343",
     "name": "Green Peace"
   },
   {
-    "hex": " #647146 ",
+    "hex": "#647146 ",
     "label": "K-344",
     "name": "Woodland Park"
   },
   {
-    "hex": " #808f67 ",
+    "hex": "#808f67 ",
     "label": "K-345",
     "name": "Forest Ranger"
   },
   {
-    "hex": " #8f9d73 ",
+    "hex": "#8f9d73 ",
     "label": "K-346",
     "name": "Cedar Lake"
   },
   {
-    "hex": " #9dad88 ",
+    "hex": "#9dad88 ",
     "label": "K-347",
     "name": "Majestic Mountain"
   },
   {
-    "hex": " #afbd9b ",
+    "hex": "#afbd9b ",
     "label": "K-348",
     "name": "Spanish Moss"
   },
   {
-    "hex": " #c9d7b7 ",
+    "hex": "#c9d7b7 ",
     "label": "K-349",
     "name": "Light Loden"
   },
   {
-    "hex": " #d7e1c8 ",
+    "hex": "#d7e1c8 ",
     "label": "K-350",
     "name": "Villa Grove"
   },
   {
-    "hex": " #e3e9d5 ",
+    "hex": "#e3e9d5 ",
     "label": "K-351",
     "name": "Gardener's Delight"
   },
   {
-    "hex": " #77a534 ",
+    "hex": "#77a534 ",
     "label": "K-352",
     "name": "Latest Look"
   },
   {
-    "hex": " #9abf59 ",
+    "hex": "#9abf59 ",
     "label": "K-353",
     "name": "Sour Apple"
   },
   {
-    "hex": " #b1d07d ",
+    "hex": "#b1d07d ",
     "label": "K-354",
     "name": "Lick of Lime"
   },
   {
-    "hex": " #c7de9c ",
+    "hex": "#c7de9c ",
     "label": "K-355",
     "name": "Snappy Green"
   },
   {
-    "hex": " #d8eab6 ",
+    "hex": "#d8eab6 ",
     "label": "K-356",
     "name": "Point Pleasant Heights"
   },
   {
-    "hex": " #e6f0cc ",
+    "hex": "#e6f0cc ",
     "label": "K-357",
     "name": "Glory of Spring"
   },
   {
-    "hex": " #ecf2d6 ",
+    "hex": "#ecf2d6 ",
     "label": "K-358",
     "name": "Kiwi Kiss"
   },
   {
-    "hex": " #f0f3de ",
+    "hex": "#f0f3de ",
     "label": "K-359",
     "name": "Spring Promise"
   },
   {
-    "hex": " #7e8947 ",
+    "hex": "#7e8947 ",
     "label": "K-360",
     "name": "Limerick Trick"
   },
   {
-    "hex": " #8d9a5b ",
+    "hex": "#8d9a5b ",
     "label": "K-361",
     "name": "Jean's Greens"
   },
   {
-    "hex": " #a9b57d ",
+    "hex": "#a9b57d ",
     "label": "K-362",
     "name": "Spring Ahead"
   },
   {
-    "hex": " #c1cb9a ",
+    "hex": "#c1cb9a ",
     "label": "K-363",
     "name": "English Countryside"
   },
   {
-    "hex": " #cedaac ",
+    "hex": "#cedaac ",
     "label": "K-364",
     "name": "Green of Spring"
   },
   {
-    "hex": " #d7e1b9 ",
+    "hex": "#d7e1b9 ",
     "label": "K-365",
     "name": "Pick of the Meadow"
   },
   {
-    "hex": " #e7ecd1 ",
+    "hex": "#e7ecd1 ",
     "label": "K-366",
     "name": "Glimpse of Spring"
   },
   {
-    "hex": " #ecefdb ",
+    "hex": "#ecefdb ",
     "label": "K-367",
     "name": "New Green"
   },
   {
-    "hex": " #77973a ",
+    "hex": "#77973a ",
     "label": "K-368",
     "name": "Luscious Lime"
   },
   {
-    "hex": " #97b35d ",
+    "hex": "#97b35d ",
     "label": "K-369",
     "name": "Green Apple Peels"
   },
   {
-    "hex": " #aec77e ",
+    "hex": "#aec77e ",
     "label": "K-370",
     "name": "Limeade"
   },
   {
-    "hex": " #c3d699 ",
+    "hex": "#c3d699 ",
     "label": "K-371",
     "name": "Spring Has Sprung"
   },
   {
-    "hex": " #d3e5b2 ",
+    "hex": "#d3e5b2 ",
     "label": "K-372",
     "name": "Loire Valley"
   },
   {
-    "hex": " #dceabf ",
+    "hex": "#dceabf ",
     "label": "K-373",
     "name": "Green Acres"
   },
   {
-    "hex": " #e6efcf ",
+    "hex": "#e6efcf ",
     "label": "K-374",
     "name": "Perennial Path"
   },
   {
-    "hex": " #ecf1d8 ",
+    "hex": "#ecf1d8 ",
     "label": "K-375",
     "name": "Soft Fern"
   },
   {
-    "hex": " #a1be1a ",
+    "hex": "#a1be1a ",
     "label": "K-376",
     "name": "Sporting Green"
   },
   {
-    "hex": " #afd54f ",
+    "hex": "#afd54f ",
     "label": "K-377",
     "name": "Burst of Lime"
   },
   {
-    "hex": " #c8e17b ",
+    "hex": "#c8e17b ",
     "label": "K-378",
     "name": "Fresh Lettuce"
   },
   {
-    "hex": " #dbeba1 ",
+    "hex": "#dbeba1 ",
     "label": "K-379",
     "name": "Peeled Pistacchio"
   },
   {
-    "hex": " #e5f1b7 ",
+    "hex": "#e5f1b7 ",
     "label": "K-380",
     "name": "Chelsea Garden"
   },
   {
-    "hex": " #ebf1c5 ",
+    "hex": "#ebf1c5 ",
     "label": "K-381",
     "name": "Spring Glen"
   },
   {
-    "hex": " #f0f4d4 ",
+    "hex": "#f0f4d4 ",
     "label": "K-382",
     "name": "Joy of Nature"
   },
   {
-    "hex": " #f3f5de ",
+    "hex": "#f3f5de ",
     "label": "K-383",
     "name": "Soft Spring"
   },
   {
-    "hex": " #97a631 ",
+    "hex": "#97a631 ",
     "label": "K-384",
     "name": "Parisan Park"
   },
   {
-    "hex": " #aebc58 ",
+    "hex": "#aebc58 ",
     "label": "K-385",
     "name": "Jive Clive"
   },
   {
-    "hex": " #c8d27e ",
+    "hex": "#c8d27e ",
     "label": "K-386",
     "name": "Alligator Alley"
   },
   {
-    "hex": " #d5dd96 ",
+    "hex": "#d5dd96 ",
     "label": "K-387",
     "name": "Spring Garden Walk"
   },
   {
-    "hex": " #e4eab3 ",
+    "hex": "#e4eab3 ",
     "label": "K-388",
     "name": "Sparkling Spring"
   },
   {
-    "hex": " #e8edbe ",
+    "hex": "#e8edbe ",
     "label": "K-389",
     "name": "Spring Bounty"
   },
   {
-    "hex": " #eff1cd ",
+    "hex": "#eff1cd ",
     "label": "K-390",
     "name": "Soft Shamrock"
   },
   {
-    "hex": " #f2f2d6 ",
+    "hex": "#f2f2d6 ",
     "label": "K-391",
     "name": "Burst of Spring"
   },
   {
-    "hex": " #c8d62d ",
+    "hex": "#c8d62d ",
     "label": "K-392",
     "name": "Sour Lime"
   },
   {
-    "hex": " #d4dd4c ",
+    "hex": "#d4dd4c ",
     "label": "K-393",
     "name": "Wow"
   },
   {
-    "hex": " #d6e36f ",
+    "hex": "#d6e36f ",
     "label": "K-394",
     "name": "Lime Ricky"
   },
   {
-    "hex": " #dce787 ",
+    "hex": "#dce787 ",
     "label": "K-395",
     "name": "Neon Lights"
   },
   {
-    "hex": " #dfe7a0 ",
+    "hex": "#dfe7a0 ",
     "label": "K-396",
     "name": "Fresh Sprout"
   },
   {
-    "hex": " #eaefc0 ",
+    "hex": "#eaefc0 ",
     "label": "K-397",
     "name": "Green Mile"
   },
   {
-    "hex": " #eeefc9 ",
+    "hex": "#eeefc9 ",
     "label": "K-398",
     "name": "Chipper Tint"
   },
   {
-    "hex": " #f3f4d9 ",
+    "hex": "#f3f4d9 ",
     "label": "K-399",
     "name": "Green Whisp"
   },
   {
-    "hex": " #707145 ",
+    "hex": "#707145 ",
     "label": "K-400",
     "name": "Tuscany Hillside"
   },
   {
-    "hex": " #888b5d ",
+    "hex": "#888b5d ",
     "label": "K-401",
     "name": "Point Verde"
   },
   {
-    "hex": " #9b9e71 ",
+    "hex": "#9b9e71 ",
     "label": "K-402",
     "name": "Aged Avocado"
   },
   {
-    "hex": " #aaad86 ",
+    "hex": "#aaad86 ",
     "label": "K-403",
     "name": "Portsmouth Olive"
   },
   {
-    "hex": " #babd9a ",
+    "hex": "#babd9a ",
     "label": "K-404",
     "name": "Golden Shores"
   },
   {
-    "hex": " #ced1ac ",
+    "hex": "#ced1ac ",
     "label": "K-405",
     "name": "Golden Chartreuse"
   },
   {
-    "hex": " #e0e2c7 ",
+    "hex": "#e0e2c7 ",
     "label": "K-406",
     "name": "Spring Frolic"
   },
   {
-    "hex": " #e8e9d4 ",
+    "hex": "#e8e9d4 ",
     "label": "K-407",
     "name": "A New Leaf"
   },
   {
-    "hex": " #7c7947 ",
+    "hex": "#7c7947 ",
     "label": "K-408",
     "name": "Cedar Edge"
   },
   {
-    "hex": " #8c8a5b ",
+    "hex": "#8c8a5b ",
     "label": "K-409",
     "name": "Aged Olive"
   },
   {
-    "hex": " #9a9764 ",
+    "hex": "#9a9764 ",
     "label": "K-410",
     "name": "Retro Avocado"
   },
   {
-    "hex": " #a8a77b ",
+    "hex": "#a8a77b ",
     "label": "K-411",
     "name": "Mossy Log"
   },
   {
-    "hex": " #bdbc93 ",
+    "hex": "#bdbc93 ",
     "label": "K-412",
     "name": "Jungle Cane"
   },
   {
-    "hex": " #d2d2a9 ",
+    "hex": "#d2d2a9 ",
     "label": "K-413",
     "name": "Hillsmere"
   },
   {
-    "hex": " #e2e0c2 ",
+    "hex": "#e2e0c2 ",
     "label": "K-414",
     "name": "Villa Nova"
   },
   {
-    "hex": " #e9e8d0 ",
+    "hex": "#e9e8d0 ",
     "label": "K-415",
     "name": "Arbor Field"
   },
   {
-    "hex": " #959143 ",
+    "hex": "#959143 ",
     "label": "K-416",
     "name": "Spring Fancy"
   },
   {
-    "hex": " #a29f54 ",
+    "hex": "#a29f54 ",
     "label": "K-417",
     "name": "Halls of Ivy"
   },
   {
-    "hex": " #b0ac62 ",
+    "hex": "#b0ac62 ",
     "label": "K-418",
     "name": "Sweet Celery"
   },
   {
-    "hex": " #bbba77 ",
+    "hex": "#bbba77 ",
     "label": "K-419",
     "name": "Young Green"
   },
   {
-    "hex": " #cdcb91 ",
+    "hex": "#cdcb91 ",
     "label": "K-420",
     "name": "Frontenac Hills"
   },
   {
-    "hex": " #dcdcaa ",
+    "hex": "#dcdcaa ",
     "label": "K-421",
     "name": "Spring Farm"
   },
   {
-    "hex": " #e9e8c2 ",
+    "hex": "#e9e8c2 ",
     "label": "K-422",
     "name": "Sunny Knoll"
   },
   {
-    "hex": " #eeedd0 ",
+    "hex": "#eeedd0 ",
     "label": "K-423",
     "name": "White Marsh"
   },
   {
-    "hex": " #9b9b39 ",
+    "hex": "#9b9b39 ",
     "label": "K-424",
     "name": "National Forest"
   },
   {
-    "hex": " #bfb95c ",
+    "hex": "#bfb95c ",
     "label": "K-425",
     "name": "Terra Verde"
   },
   {
-    "hex": " #d2cc7a ",
+    "hex": "#d2cc7a ",
     "label": "K-426",
     "name": "Italian Olive"
   },
   {
-    "hex": " #d7d288 ",
+    "hex": "#d7d288 ",
     "label": "K-427",
     "name": "Garden Promenade"
   },
   {
-    "hex": " #e1dd9e ",
+    "hex": "#e1dd9e ",
     "label": "K-428",
     "name": "Meadow Marsh"
   },
   {
-    "hex": " #ede8b5 ",
+    "hex": "#ede8b5 ",
     "label": "K-429",
     "name": "Sprig of Sage"
   },
   {
-    "hex": " #f0edc4 ",
+    "hex": "#f0edc4 ",
     "label": "K-430",
     "name": "Provincial Garden"
   },
   {
-    "hex": " #f3f0d0 ",
+    "hex": "#f3f0d0 ",
     "label": "K-431",
     "name": "Spirit Island"
   },
   {
-    "hex": " #cdbc09 ",
+    "hex": "#cdbc09 ",
     "label": "K-432",
     "name": "Miss Marigold"
   },
   {
-    "hex": " #e9d959 ",
+    "hex": "#e9d959 ",
     "label": "K-433",
     "name": "Sun Bright"
   },
   {
-    "hex": " #ecdf7a ",
+    "hex": "#ecdf7a ",
     "label": "K-434",
     "name": "Bold Gold"
   },
   {
-    "hex": " #f2ea9c ",
+    "hex": "#f2ea9c ",
     "label": "K-435",
     "name": "Golden Treasure"
   },
   {
-    "hex": " #faf2b8 ",
+    "hex": "#faf2b8 ",
     "label": "K-436",
     "name": "Sun Fun"
   },
   {
-    "hex": " #f8f3c5 ",
+    "hex": "#f8f3c5 ",
     "label": "K-437",
     "name": "Gold Gleam"
   },
   {
-    "hex": " #f7f4d8 ",
+    "hex": "#f7f4d8 ",
     "label": "K-438",
     "name": "Golden Season"
   },
   {
-    "hex": " #f6f4e1 ",
+    "hex": "#f6f4e1 ",
     "label": "K-439",
     "name": "Summer Fun"
   },
   {
-    "hex": " #a09238 ",
+    "hex": "#a09238 ",
     "label": "K-440",
     "name": "Ornamental Grass"
   },
   {
-    "hex": " #bbac59 ",
+    "hex": "#bbac59 ",
     "label": "K-441",
     "name": "Garden Element"
   },
   {
-    "hex": " #d2c680 ",
+    "hex": "#d2c680 ",
     "label": "K-442",
     "name": "Avalon"
   },
   {
-    "hex": " #ded49a ",
+    "hex": "#ded49a ",
     "label": "K-443",
     "name": "Divine Vine"
   },
   {
-    "hex": " #ebe4b4 ",
+    "hex": "#ebe4b4 ",
     "label": "K-444",
     "name": "Meadowland"
   },
   {
-    "hex": " #f3eecb ",
+    "hex": "#f3eecb ",
     "label": "K-445",
     "name": "Harmony Hills"
   },
   {
-    "hex": " #f3efd4 ",
+    "hex": "#f3efd4 ",
     "label": "K-446",
     "name": "Kindred Spirit"
   },
   {
-    "hex": " #f5f3df ",
+    "hex": "#f5f3df ",
     "label": "K-447",
     "name": "Angel Kiss"
   },
   {
-    "hex": " #7a7139 ",
+    "hex": "#7a7139 ",
     "label": "K-448",
     "name": "Veradale"
   },
   {
-    "hex": " #a0955d ",
+    "hex": "#a0955d ",
     "label": "K-449",
     "name": "Olive Oil"
   },
   {
-    "hex": " #b3a772 ",
+    "hex": "#b3a772 ",
     "label": "K-450",
     "name": "Sheffield"
   },
   {
-    "hex": " #c1b78a ",
+    "hex": "#c1b78a ",
     "label": "K-451",
     "name": "Bamboo Shoot"
   },
   {
-    "hex": " #cfc89f ",
+    "hex": "#cfc89f ",
     "label": "K-452",
     "name": "Gold Mountain"
   },
   {
-    "hex": " #e0d8b4 ",
+    "hex": "#e0d8b4 ",
     "label": "K-453",
     "name": "Banana Cream"
   },
   {
-    "hex": " #e8e2c4 ",
+    "hex": "#e8e2c4 ",
     "label": "K-454",
     "name": "Pale Papyrus"
   },
   {
-    "hex": " #f0edda ",
+    "hex": "#f0edda ",
     "label": "K-455",
     "name": "Windswept Sails"
   },
   {
-    "hex": " #baa736 ",
+    "hex": "#baa736 ",
     "label": "K-456",
     "name": "The Open Range"
   },
   {
-    "hex": " #d0be55 ",
+    "hex": "#d0be55 ",
     "label": "K-457",
     "name": "September Sun"
   },
   {
-    "hex": " #e0d27d ",
+    "hex": "#e0d27d ",
     "label": "K-458",
     "name": "Australian Outlook"
   },
   {
-    "hex": " #ebde99 ",
+    "hex": "#ebde99 ",
     "label": "K-459",
     "name": "Goldiluxe"
   },
   {
-    "hex": " #f3eab3 ",
+    "hex": "#f3eab3 ",
     "label": "K-460",
     "name": "Honey Heaven"
   },
   {
-    "hex": " #f4efc8 ",
+    "hex": "#f4efc8 ",
     "label": "K-461",
     "name": "Happy Honey"
   },
   {
-    "hex": " #f5f1d4 ",
+    "hex": "#f5f1d4 ",
     "label": "K-462",
     "name": "Natural Linen"
   },
   {
-    "hex": " #f4f2dd ",
+    "hex": "#f4f2dd ",
     "label": "K-463",
     "name": "Thickened Cream"
   },
   {
-    "hex": " #ffd704 ",
+    "hex": "#ffd704 ",
     "label": "K-464",
     "name": "Under the Sun"
   },
   {
-    "hex": " #ffe449 ",
+    "hex": "#ffe449 ",
     "label": "K-465",
     "name": "Rajah Gold"
   },
   {
-    "hex": " #ffeb7a ",
+    "hex": "#ffeb7a ",
     "label": "K-466",
     "name": "Summer Yellow"
   },
   {
-    "hex": " #feee91 ",
+    "hex": "#feee91 ",
     "label": "K-467",
     "name": "Lemon Burst"
   },
   {
-    "hex": " #faf2b3 ",
+    "hex": "#faf2b3 ",
     "label": "K-468",
     "name": "Rise and Shine"
   },
   {
-    "hex": " #f9f3c4 ",
+    "hex": "#f9f3c4 ",
     "label": "K-469",
     "name": "Sunshiny"
   },
   {
-    "hex": " #f7f3d1 ",
+    "hex": "#f7f3d1 ",
     "label": "K-470",
     "name": "Sunny Companion"
   },
   {
-    "hex": " #f7f5dc ",
+    "hex": "#f7f5dc ",
     "label": "K-471",
     "name": "Summer Style"
   },
   {
-    "hex": " #ffcc00 ",
+    "hex": "#ffcc00 ",
     "label": "K-472",
     "name": "Golden Ray"
   },
   {
-    "hex": " #ffda40 ",
+    "hex": "#ffda40 ",
     "label": "K-473",
     "name": "Sunflower Petal"
   },
   {
-    "hex": " #ffe372 ",
+    "hex": "#ffe372 ",
     "label": "K-474",
     "name": "Country Sun"
   },
   {
-    "hex": " #ffec95 ",
+    "hex": "#ffec95 ",
     "label": "K-475",
     "name": "Saffron Smile"
   },
   {
-    "hex": " #fcf1b7 ",
+    "hex": "#fcf1b7 ",
     "label": "K-476",
     "name": "Lemon Rose"
   },
   {
-    "hex": " #f9f0c3 ",
+    "hex": "#f9f0c3 ",
     "label": "K-477",
     "name": "Sunny Sanibel"
   },
   {
-    "hex": " #f8f4d8 ",
+    "hex": "#f8f4d8 ",
     "label": "K-478",
     "name": "Shining Bright"
   },
   {
-    "hex": " #f7f5e1 ",
+    "hex": "#f7f5e1 ",
     "label": "K-479",
     "name": "Soft Honey"
   },
   {
-    "hex": " #bc9b32 ",
+    "hex": "#bc9b32 ",
     "label": "K-480",
     "name": "Golden Rattan"
   },
   {
-    "hex": " #cdae4e ",
+    "hex": "#cdae4e ",
     "label": "K-481",
     "name": "Slip into Sunset"
   },
   {
-    "hex": " #dbbc61 ",
+    "hex": "#dbbc61 ",
     "label": "K-482",
     "name": "The Outback"
   },
   {
-    "hex": " #ead38f ",
+    "hex": "#ead38f ",
     "label": "K-483",
     "name": "Honey Mustard"
   },
   {
-    "hex": " #f1e0a5 ",
+    "hex": "#f1e0a5 ",
     "label": "K-484",
     "name": "Sea Oats"
   },
   {
-    "hex": " #f4e7b8 ",
+    "hex": "#f4e7b8 ",
     "label": "K-485",
     "name": "Sunny Disposition"
   },
   {
-    "hex": " #f9f2cf ",
+    "hex": "#f9f2cf ",
     "label": "K-486",
     "name": "Yuma Sand"
   },
   {
-    "hex": " #f8f3da ",
+    "hex": "#f8f3da ",
     "label": "K-487",
     "name": "Irish Linen"
   },
   {
-    "hex": " #a98840 ",
+    "hex": "#a98840 ",
     "label": "K-488",
     "name": "Gold Strike"
   },
   {
-    "hex": " #bc9d58 ",
+    "hex": "#bc9d58 ",
     "label": "K-489",
     "name": "Botanica Gold"
   },
   {
-    "hex": " #c5a863 ",
+    "hex": "#c5a863 ",
     "label": "K-490",
     "name": "Sunshine Yellow"
   },
   {
-    "hex": " #d2b87b ",
+    "hex": "#d2b87b ",
     "label": "K-491",
     "name": "Star Fire"
   },
   {
-    "hex": " #e2cc9a ",
+    "hex": "#e2cc9a ",
     "label": "K-492",
     "name": "Pale Pollen"
   },
   {
-    "hex": " #ecdbad ",
+    "hex": "#ecdbad ",
     "label": "K-493",
     "name": "Sun Glory"
   },
   {
-    "hex": " #f1e4bf ",
+    "hex": "#f1e4bf ",
     "label": "K-494",
     "name": "French Sonnet"
   },
   {
-    "hex": " #f3ecd4 ",
+    "hex": "#f3ecd4 ",
     "label": "K-495",
     "name": "Pale Ivory"
   },
   {
-    "hex": " #f2ba2b ",
+    "hex": "#f2ba2b ",
     "label": "K-496",
     "name": "Devonshire"
   },
   {
-    "hex": " #f9d154 ",
+    "hex": "#f9d154 ",
     "label": "K-497",
     "name": "Sunland Park"
   },
   {
-    "hex": " #fbdc75 ",
+    "hex": "#fbdc75 ",
     "label": "K-498",
     "name": "Tons of Sun"
   },
   {
-    "hex": " #fde38d ",
+    "hex": "#fde38d ",
     "label": "K-499",
     "name": "Sunlit Sand"
   },
   {
-    "hex": " #fdf0b5 ",
+    "hex": "#fdf0b5 ",
     "label": "K-500",
     "name": "Cream Custard"
   },
   {
-    "hex": " #fcf2be ",
+    "hex": "#fcf2be ",
     "label": "K-501",
     "name": "Autumn Valley"
   },
   {
-    "hex": " #faf3cd ",
+    "hex": "#faf3cd ",
     "label": "K-502",
     "name": "Spring Fever"
   },
   {
-    "hex": " #f8f4d9 ",
+    "hex": "#f8f4d9 ",
     "label": "K-503",
     "name": "Lynne Acres"
   },
   {
-    "hex": " #eab41e ",
+    "hex": "#eab41e ",
     "label": "K-504",
     "name": "Dried Mustard"
   },
   {
-    "hex": " #f6ca51 ",
+    "hex": "#f6ca51 ",
     "label": "K-505",
     "name": "Somerton"
   },
   {
-    "hex": " #f9d877 ",
+    "hex": "#f9d877 ",
     "label": "K-506",
     "name": "Mayan Maize"
   },
   {
-    "hex": " #fce59c ",
+    "hex": "#fce59c ",
     "label": "K-507",
     "name": "Southern Exposure"
   },
   {
-    "hex": " #fbedb3 ",
+    "hex": "#fbedb3 ",
     "label": "K-508",
     "name": "Senegal Sun"
   },
   {
-    "hex": " #fbf1c6 ",
+    "hex": "#fbf1c6 ",
     "label": "K-509",
     "name": "Fun in the Sun"
   },
   {
-    "hex": " #f9f3d3 ",
+    "hex": "#f9f3d3 ",
     "label": "K-510",
     "name": "Vanilla Almond"
   },
   {
-    "hex": " #f8f4dd ",
+    "hex": "#f8f4dd ",
     "label": "K-511",
     "name": "Evening Moon"
   },
   {
-    "hex": " #ffc300 ",
+    "hex": "#ffc300 ",
     "label": "K-512",
     "name": "Inca Gold"
   },
   {
-    "hex": " #ffd23b ",
+    "hex": "#ffd23b ",
     "label": "K-513",
     "name": "Golden Girl"
   },
   {
-    "hex": " #ffe175 ",
+    "hex": "#ffe175 ",
     "label": "K-514",
     "name": "Ski Valley"
   },
   {
-    "hex": " #ffe898 ",
+    "hex": "#ffe898 ",
     "label": "K-515",
     "name": "Solid Gold"
   },
   {
-    "hex": " #ffeeb1 ",
+    "hex": "#ffeeb1 ",
     "label": "K-516",
     "name": "Golden Aura"
   },
   {
-    "hex": " #fcf0c0 ",
+    "hex": "#fcf0c0 ",
     "label": "K-517",
     "name": "Sundrenched"
   },
   {
-    "hex": " #faf3d4 ",
+    "hex": "#faf3d4 ",
     "label": "K-518",
     "name": "Liquid Light"
   },
   {
-    "hex": " #f7f5e4 ",
+    "hex": "#f7f5e4 ",
     "label": "K-519",
     "name": "Firefly Flicker"
   },
   {
-    "hex": " #f0a90a ",
+    "hex": "#f0a90a ",
     "label": "K-520",
     "name": "Golden Autumn"
   },
   {
-    "hex": " #f8ba38 ",
+    "hex": "#f8ba38 ",
     "label": "K-521",
     "name": "Antique Gold"
   },
   {
-    "hex": " #ffcc61 ",
+    "hex": "#ffcc61 ",
     "label": "K-522",
     "name": "Burnished Sun"
   },
   {
-    "hex": " #ffdb8c ",
+    "hex": "#ffdb8c ",
     "label": "K-523",
     "name": "Hawaiian Honey"
   },
   {
-    "hex": " #ffe7a7 ",
+    "hex": "#ffe7a7 ",
     "label": "K-524",
     "name": "Sommerset"
   },
   {
-    "hex": " #ffedba ",
+    "hex": "#ffedba ",
     "label": "K-525",
     "name": "Wild Honey"
   },
   {
-    "hex": " #fdf0ca ",
+    "hex": "#fdf0ca ",
     "label": "K-526",
     "name": "Sprinkled with Summer"
   },
   {
-    "hex": " #fbf2d6 ",
+    "hex": "#fbf2d6 ",
     "label": "K-527",
     "name": "Lunar Luxury"
   },
   {
-    "hex": " #d29c31 ",
+    "hex": "#d29c31 ",
     "label": "K-528",
     "name": "Field Gear"
   },
   {
-    "hex": " #e1b150 ",
+    "hex": "#e1b150 ",
     "label": "K-529",
     "name": "Serengeti Song"
   },
   {
-    "hex": " #efc674 ",
+    "hex": "#efc674 ",
     "label": "K-530",
     "name": "Sari Suit"
   },
   {
-    "hex": " #f8d897 ",
+    "hex": "#f8d897 ",
     "label": "K-531",
     "name": "Creased Khaki"
   },
   {
-    "hex": " #fbe4ab ",
+    "hex": "#fbe4ab ",
     "label": "K-532",
     "name": "Natural Raffia"
   },
   {
-    "hex": " #faebbf ",
+    "hex": "#faebbf ",
     "label": "K-533",
     "name": "Home and Hearth"
   },
   {
-    "hex": " #f8f0d6 ",
+    "hex": "#f8f0d6 ",
     "label": "K-534",
     "name": "Shredded Wheat"
   },
   {
-    "hex": " #f7f4e6 ",
+    "hex": "#f7f4e6 ",
     "label": "K-535",
     "name": "Washed Canvas"
   },
   {
-    "hex": " #ca933e ",
+    "hex": "#ca933e ",
     "label": "K-536",
     "name": "Chapultepec"
   },
   {
-    "hex": " #dba755 ",
+    "hex": "#dba755 ",
     "label": "K-537",
     "name": "Great Gaucho"
   },
   {
-    "hex": " #e8bb73 ",
+    "hex": "#e8bb73 ",
     "label": "K-538",
     "name": "West Warwick"
   },
   {
-    "hex": " #f0c989 ",
+    "hex": "#f0c989 ",
     "label": "K-539",
     "name": "Hacienda Clay"
   },
   {
-    "hex": " #fadeaa ",
+    "hex": "#fadeaa ",
     "label": "K-540",
     "name": "Sea of Sand"
   },
   {
-    "hex": " #fbe9c3 ",
+    "hex": "#fbe9c3 ",
     "label": "K-541",
     "name": "Clean Canvas"
   },
   {
-    "hex": " #f9f0da ",
+    "hex": "#f9f0da ",
     "label": "K-542",
     "name": "Magnolia Bloom"
   },
   {
-    "hex": " #f7f3e6 ",
+    "hex": "#f7f3e6 ",
     "label": "K-543",
     "name": "Moon Magic"
   },
   {
-    "hex": " #ffb400 ",
+    "hex": "#ffb400 ",
     "label": "K-544",
     "name": "Bright Lily"
   },
   {
-    "hex": " #ffc82b ",
+    "hex": "#ffc82b ",
     "label": "K-545",
     "name": "Goldfinch"
   },
   {
-    "hex": " #ffd668 ",
+    "hex": "#ffd668 ",
     "label": "K-546",
     "name": "Bright Fires"
   },
   {
-    "hex": " #ffe28f ",
+    "hex": "#ffe28f ",
     "label": "K-547",
     "name": "Tigger's Tail"
   },
   {
-    "hex": " #ffeaa7 ",
+    "hex": "#ffeaa7 ",
     "label": "K-548",
     "name": "Bee Balm"
   },
   {
-    "hex": " #ffedba ",
+    "hex": "#ffedba ",
     "label": "K-549",
     "name": "Tangerine Twist"
   },
   {
-    "hex": " #fcf0ca ",
+    "hex": "#fcf0ca ",
     "label": "K-550",
     "name": "Cornmeal"
   },
   {
-    "hex": " #f9f4df ",
+    "hex": "#f9f4df ",
     "label": "K-551",
     "name": "Buttered Up"
   },
   {
-    "hex": " #ffaa00 ",
+    "hex": "#ffaa00 ",
     "label": "K-552",
     "name": "Florida Orange"
   },
   {
-    "hex": " #ffba40 ",
+    "hex": "#ffba40 ",
     "label": "K-553",
     "name": "Firefly Glow"
   },
   {
-    "hex": " #ffc65a ",
+    "hex": "#ffc65a ",
     "label": "K-554",
     "name": "Orange Spark"
   },
   {
-    "hex": " #ffd98d ",
+    "hex": "#ffd98d ",
     "label": "K-555",
     "name": "Dreamsicle"
   },
   {
-    "hex": " #ffe7ad ",
+    "hex": "#ffe7ad ",
     "label": "K-556",
     "name": "Fairy Glitter"
   },
   {
-    "hex": " #feecbf ",
+    "hex": "#feecbf ",
     "label": "K-557",
     "name": "Sparkle Tint"
   },
   {
-    "hex": " #fceec8 ",
+    "hex": "#fceec8 ",
     "label": "K-558",
     "name": "Tinkerbell Trail "
   },
   {
-    "hex": " #faf1d7 ",
+    "hex": "#faf1d7 ",
     "label": "K-559",
     "name": "Apricot Mousse"
   },
   {
-    "hex": " #ff9a05 ",
+    "hex": "#ff9a05 ",
     "label": "K-560",
     "name": "Monarch Wing"
   },
   {
-    "hex": " #ffb239 ",
+    "hex": "#ffb239 ",
     "label": "K-561",
     "name": "Pumpkin Harvest"
   },
   {
-    "hex": " #ffc465 ",
+    "hex": "#ffc465 ",
     "label": "K-562",
     "name": "Autumn's Charm"
   },
   {
-    "hex": " #ffd280 ",
+    "hex": "#ffd280 ",
     "label": "K-563",
     "name": "Summer Sherbert"
   },
   {
-    "hex": " #ffe1a2 ",
+    "hex": "#ffe1a2 ",
     "label": "K-564",
     "name": "Elberta Peaches"
   },
   {
-    "hex": " #fdedc3 ",
+    "hex": "#fdedc3 ",
     "label": "K-565",
     "name": "Zahria"
   },
   {
-    "hex": " #fbf0d0 ",
+    "hex": "#fbf0d0 ",
     "label": "K-566",
     "name": "Apricotta"
   },
   {
-    "hex": " #f9f2dc ",
+    "hex": "#f9f2dc ",
     "label": "K-567",
     "name": "Vanilla View"
   },
   {
-    "hex": " #cb8135 ",
+    "hex": "#cb8135 ",
     "label": "K-568",
     "name": "Mandarin Grove"
   },
   {
-    "hex": " #e09c52 ",
+    "hex": "#e09c52 ",
     "label": "K-569",
     "name": "Autumn Beauty"
   },
   {
-    "hex": " #f0b87a ",
+    "hex": "#f0b87a ",
     "label": "K-570",
     "name": "Seville Orange"
   },
   {
-    "hex": " #f8c791 ",
+    "hex": "#f8c791 ",
     "label": "K-571",
     "name": "Citrus Sherbert"
   },
   {
-    "hex": " #fedcac ",
+    "hex": "#fedcac ",
     "label": "K-572",
     "name": "Coral Beach"
   },
   {
-    "hex": " #fce3be ",
+    "hex": "#fce3be ",
     "label": "K-573",
     "name": "Such a Peach"
   },
   {
-    "hex": " #f9edd4 ",
+    "hex": "#f9edd4 ",
     "label": "K-574",
     "name": "Rave Rachel"
   },
   {
-    "hex": " #f7f2e5 ",
+    "hex": "#f7f2e5 ",
     "label": "K-575",
     "name": "Soft Shoulders"
   },
   {
-    "hex": " #fd8323 ",
+    "hex": "#fd8323 ",
     "label": "K-576",
     "name": "Haley's Comet"
   },
   {
-    "hex": " #ffa348 ",
+    "hex": "#ffa348 ",
     "label": "K-577",
     "name": "Tangelo Anna"
   },
   {
-    "hex": " #ffb76a ",
+    "hex": "#ffb76a ",
     "label": "K-578",
     "name": "Sweet Michelle"
   },
   {
-    "hex": " #ffd096 ",
+    "hex": "#ffd096 ",
     "label": "K-579",
     "name": "Mirasol Paula"
   },
   {
-    "hex": " #ffdeab ",
+    "hex": "#ffdeab ",
     "label": "K-580",
     "name": "Ariana"
   },
   {
-    "hex": " #fee7c0 ",
+    "hex": "#fee7c0 ",
     "label": "K-581",
     "name": "Proud Mary"
   },
   {
-    "hex": " #fcedcf ",
+    "hex": "#fcedcf ",
     "label": "K-582",
     "name": "Quiche Lorraine"
   },
   {
-    "hex": " #f9efd9 ",
+    "hex": "#f9efd9 ",
     "label": "K-583",
     "name": "Christi Cream"
   },
   {
-    "hex": " #d9863a ",
+    "hex": "#d9863a ",
     "label": "K-584",
     "name": "Bergamot Orange"
   },
   {
-    "hex": " #e99d56 ",
+    "hex": "#e99d56 ",
     "label": "K-585",
     "name": "Amber Autumn"
   },
   {
-    "hex": " #f2b276 ",
+    "hex": "#f2b276 ",
     "label": "K-586",
     "name": "Sirena Sun"
   },
   {
-    "hex": " #fcc996 ",
+    "hex": "#fcc996 ",
     "label": "K-587",
     "name": "Baltic Amber"
   },
   {
-    "hex": " #ffd8ab ",
+    "hex": "#ffd8ab ",
     "label": "K-588",
     "name": "Amber Moon"
   },
   {
-    "hex": " #fee1bc ",
+    "hex": "#fee1bc ",
     "label": "K-589",
     "name": "Moonlight Beach"
   },
   {
-    "hex": " #fae9cf ",
+    "hex": "#fae9cf ",
     "label": "K-590",
     "name": "Cumberland Cream"
   },
   {
-    "hex": " #faf0de ",
+    "hex": "#faf0de ",
     "label": "K-591",
     "name": "Moon Maiden"
   },
   {
-    "hex": " #e87434 ",
+    "hex": "#e87434 ",
     "label": "K-592",
     "name": "Bright Bittersweet"
   },
   {
-    "hex": " #fe9150 ",
+    "hex": "#fe9150 ",
     "label": "K-593",
     "name": "Autumn Splendor"
   },
   {
-    "hex": " #ffaa76 ",
+    "hex": "#ffaa76 ",
     "label": "K-594",
     "name": "Coral Canyon"
   },
   {
-    "hex": " #ffc599 ",
+    "hex": "#ffc599 ",
     "label": "K-595",
     "name": "Sunset Beach"
   },
   {
-    "hex": " #ffd6af ",
+    "hex": "#ffd6af ",
     "label": "K-596",
     "name": "Melon Sorbet"
   },
   {
-    "hex": " #ffe3c6 ",
+    "hex": "#ffe3c6 ",
     "label": "K-597",
     "name": "Peach Rose"
   },
   {
-    "hex": " #fcead3 ",
+    "hex": "#fcead3 ",
     "label": "K-598",
     "name": "Simply Sunset"
   },
   {
-    "hex": " #f9f1e1 ",
+    "hex": "#f9f1e1 ",
     "label": "K-599",
     "name": "Villa Nor"
   },
   {
-    "hex": " #d26b33 ",
+    "hex": "#d26b33 ",
     "label": "K-600",
     "name": "Deep Spice"
   },
   {
-    "hex": " #eb905b ",
+    "hex": "#eb905b ",
     "label": "K-601",
     "name": "Cimarron Trail"
   },
   {
-    "hex": " #f5a779 ",
+    "hex": "#f5a779 ",
     "label": "K-602",
     "name": "Moroccan Spice"
   },
   {
-    "hex": " #fabb93 ",
+    "hex": "#fabb93 ",
     "label": "K-603",
     "name": "Fawn Farrah"
   },
   {
-    "hex": " #ffd2b0 ",
+    "hex": "#ffd2b0 ",
     "label": "K-604",
     "name": "Dunhill"
   },
   {
-    "hex": " #fedcc1 ",
+    "hex": "#fedcc1 ",
     "label": "K-605",
     "name": "Bashful Beige"
   },
   {
-    "hex": " #fbead8 ",
+    "hex": "#fbead8 ",
     "label": "K-606",
     "name": "Pale Dawn"
   },
   {
-    "hex": " #f7f2e6 ",
+    "hex": "#f7f2e6 ",
     "label": "K-607",
     "name": "Thistle Down"
   },
   {
-    "hex": " #ae6241 ",
+    "hex": "#ae6241 ",
     "label": "K-608",
     "name": "Sunbaked Earth"
   },
   {
-    "hex": " #d07c50 ",
+    "hex": "#d07c50 ",
     "label": "K-609",
     "name": "Tuscan Terracotta"
   },
   {
-    "hex": " #e39d77 ",
+    "hex": "#e39d77 ",
     "label": "K-610",
     "name": "Beach Treasure"
   },
   {
-    "hex": " #f0b798 ",
+    "hex": "#f0b798 ",
     "label": "K-611",
     "name": "Sun-warmed Tile"
   },
   {
-    "hex": " #f6c9aa ",
+    "hex": "#f6c9aa ",
     "label": "K-612",
     "name": "Orange Essence"
   },
   {
-    "hex": " #f9d4b8 ",
+    "hex": "#f9d4b8 ",
     "label": "K-613",
     "name": "Peach Beach"
   },
   {
-    "hex": " #f9dfc8 ",
+    "hex": "#f9dfc8 ",
     "label": "K-614",
     "name": "Toes in the Sand"
   },
   {
-    "hex": " #fae6d5 ",
+    "hex": "#fae6d5 ",
     "label": "K-615",
     "name": "Milk Shake"
   },
   {
-    "hex": " #af633e ",
+    "hex": "#af633e ",
     "label": "K-616",
     "name": "Copper Moon"
   },
   {
-    "hex": " #bc734b ",
+    "hex": "#bc734b ",
     "label": "K-617",
     "name": "Timeworn Terracotta"
   },
   {
-    "hex": " #d4916e ",
+    "hex": "#d4916e ",
     "label": "K-618",
     "name": "Sunset Mesa"
   },
   {
-    "hex": " #e0a380 ",
+    "hex": "#e0a380 ",
     "label": "K-619",
     "name": "Coral Coast"
   },
   {
-    "hex": " #f2c19f ",
+    "hex": "#f2c19f ",
     "label": "K-620",
     "name": "Salmon River"
   },
   {
-    "hex": " #f6d0b3 ",
+    "hex": "#f6d0b3 ",
     "label": "K-621",
     "name": "Australian Apricot"
   },
   {
-    "hex": " #f9e1cb ",
+    "hex": "#f9e1cb ",
     "label": "K-622",
     "name": "Coral Cloud"
   },
   {
-    "hex": " #f7ecde ",
+    "hex": "#f7ecde ",
     "label": "K-623",
     "name": "African Ivory"
   },
   {
-    "hex": " #ed6136 ",
+    "hex": "#ed6136 ",
     "label": "K-624",
     "name": "Hot Shot"
   },
   {
-    "hex": " #fa8658 ",
+    "hex": "#fa8658 ",
     "label": "K-625",
     "name": "Mathew's Fire"
   },
   {
-    "hex": " #fea17d ",
+    "hex": "#fea17d ",
     "label": "K-626",
     "name": "Orange You Glad"
   },
   {
-    "hex": " #ffbb9d ",
+    "hex": "#ffbb9d ",
     "label": "K-627",
     "name": "Orange Nectar"
   },
   {
-    "hex": " #ffcfb5 ",
+    "hex": "#ffcfb5 ",
     "label": "K-628",
     "name": "Mango Tango"
   },
   {
-    "hex": " #ffdec8 ",
+    "hex": "#ffdec8 ",
     "label": "K-629",
     "name": "Luminaria"
   },
   {
-    "hex": " #fde9d9 ",
+    "hex": "#fde9d9 ",
     "label": "K-630",
     "name": "Peach Cashmere"
   },
   {
-    "hex": " #f8eee2 ",
+    "hex": "#f8eee2 ",
     "label": "K-631",
     "name": "Peach Complexion"
   },
   {
-    "hex": " #be4e3d ",
+    "hex": "#be4e3d ",
     "label": "K-632",
     "name": "Persimmon"
   },
   {
-    "hex": " #e17d63 ",
+    "hex": "#e17d63 ",
     "label": "K-633",
     "name": "Coral Cove"
   },
   {
-    "hex": " #f09d8a ",
+    "hex": "#f09d8a ",
     "label": "K-634",
     "name": "Rosy Coral"
   },
   {
-    "hex": " #f8b5a4 ",
+    "hex": "#f8b5a4 ",
     "label": "K-635",
     "name": "Shade of Shell"
   },
   {
-    "hex": " #fec8b7 ",
+    "hex": "#fec8b7 ",
     "label": "K-636",
     "name": "Young Girl"
   },
   {
-    "hex": " #fed6c8 ",
+    "hex": "#fed6c8 ",
     "label": "K-637",
     "name": "Mussel Shell"
   },
   {
-    "hex": " #fde4d9 ",
+    "hex": "#fde4d9 ",
     "label": "K-638",
     "name": "Path of Petals"
   },
   {
-    "hex": " #fbeae1 ",
+    "hex": "#fbeae1 ",
     "label": "K-639",
     "name": "First Love"
   },
   {
-    "hex": " #e64e3a ",
+    "hex": "#e64e3a ",
     "label": "K-640",
     "name": "Campfire Blaze"
   },
   {
-    "hex": " #f67c6c ",
+    "hex": "#f67c6c ",
     "label": "K-641",
     "name": "Australian Coral"
   },
   {
-    "hex": " #fb988f ",
+    "hex": "#fb988f ",
     "label": "K-642",
     "name": "Adonis Glow"
   },
   {
-    "hex": " #ffb2aa ",
+    "hex": "#ffb2aa ",
     "label": "K-643",
     "name": "Perfect Touch"
   },
   {
-    "hex": " #ffccc4 ",
+    "hex": "#ffccc4 ",
     "label": "K-644",
     "name": "Deco Shell"
   },
   {
-    "hex": " #ffd8d0 ",
+    "hex": "#ffd8d0 ",
     "label": "K-645",
     "name": "Rose Hips"
   },
   {
-    "hex": " #fde3db ",
+    "hex": "#fde3db ",
     "label": "K-646",
     "name": "Sherry Cream"
   },
   {
-    "hex": " #f9ede6 ",
+    "hex": "#f9ede6 ",
     "label": "K-647",
     "name": "Gossamer"
   },
   {
-    "hex": " #cb5345 ",
+    "hex": "#cb5345 ",
     "label": "K-648",
     "name": "Grand Duke"
   },
   {
-    "hex": " #e87f79 ",
+    "hex": "#e87f79 ",
     "label": "K-649",
     "name": "Fancy Nancy"
   },
   {
-    "hex": " #f29897 ",
+    "hex": "#f29897 ",
     "label": "K-650",
     "name": "Blossom Park"
   },
   {
-    "hex": " #fab4b2 ",
+    "hex": "#fab4b2 ",
     "label": "K-651",
     "name": "Her Majesty"
   },
   {
-    "hex": " #ffc9c7 ",
+    "hex": "#ffc9c7 ",
     "label": "K-652",
     "name": "Rose Point"
   },
   {
-    "hex": " #ffd1cd ",
+    "hex": "#ffd1cd ",
     "label": "K-653",
     "name": "Bloomsbury"
   },
   {
-    "hex": " #fee1de ",
+    "hex": "#fee1de ",
     "label": "K-654",
     "name": "Morningside"
   },
   {
-    "hex": " #faebe8 ",
+    "hex": "#faebe8 ",
     "label": "K-655",
     "name": "Devon Dawn"
   },
   {
-    "hex": " #df4338 ",
+    "hex": "#df4338 ",
     "label": "K-656",
     "name": "Salsa del Sol"
   },
   {
-    "hex": " #f37773 ",
+    "hex": "#f37773 ",
     "label": "K-657",
     "name": "Gabriel's Gift"
   },
   {
-    "hex": " #fa9594 ",
+    "hex": "#fa9594 ",
     "label": "K-658",
     "name": "Peaceful Princess"
   },
   {
-    "hex": " #ffaaaa ",
+    "hex": "#ffaaaa ",
     "label": "K-659",
     "name": "Patient Pink"
   },
   {
-    "hex": " #ffc7c5 ",
+    "hex": "#ffc7c5 ",
     "label": "K-660",
     "name": "Spring Rose"
   },
   {
-    "hex": " #ffd8d5 ",
+    "hex": "#ffd8d5 ",
     "label": "K-661",
     "name": "Pink Perfection"
   },
   {
-    "hex": " #fde0dd ",
+    "hex": "#fde0dd ",
     "label": "K-662",
     "name": "My Sweatheart"
   },
   {
-    "hex": " #f9eee9 ",
+    "hex": "#f9eee9 ",
     "label": "K-663",
     "name": "Willow Creek"
   },
   {
-    "hex": " #b34b42 ",
+    "hex": "#b34b42 ",
     "label": "K-664",
     "name": "Scarlet Sumac"
   },
   {
-    "hex": " #cd6766 ",
+    "hex": "#cd6766 ",
     "label": "K-665",
     "name": "May Fair"
   },
   {
-    "hex": " #dd8489 ",
+    "hex": "#dd8489 ",
     "label": "K-666",
     "name": "Sweet Amelia"
   },
   {
-    "hex": " #eea5a7 ",
+    "hex": "#eea5a7 ",
     "label": "K-667",
     "name": "Pink Carnation"
   },
   {
-    "hex": " #f8b8b9 ",
+    "hex": "#f8b8b9 ",
     "label": "K-668",
     "name": "Desert Bloom"
   },
   {
-    "hex": " #fcc3c6 ",
+    "hex": "#fcc3c6 ",
     "label": "K-669",
     "name": "Dulce Crystal"
   },
   {
-    "hex": " #fcd7d6 ",
+    "hex": "#fcd7d6 ",
     "label": "K-670",
     "name": "Pouf of Pink"
   },
   {
-    "hex": " #f9e9e6 ",
+    "hex": "#f9e9e6 ",
     "label": "K-671",
     "name": "Pale Perfection"
   },
   {
-    "hex": " #be2535 ",
+    "hex": "#be2535 ",
     "label": "K-672",
     "name": "Red Baron"
   },
   {
-    "hex": " #e06a78 ",
+    "hex": "#e06a78 ",
     "label": "K-673",
     "name": "Lady Love"
   },
   {
-    "hex": " #ef8d9d ",
+    "hex": "#ef8d9d ",
     "label": "K-674",
     "name": "Wild Heather"
   },
   {
-    "hex": " #faaab6 ",
+    "hex": "#faaab6 ",
     "label": "K-675",
     "name": "Chelsea Rose"
   },
   {
-    "hex": " #fdbbc5 ",
+    "hex": "#fdbbc5 ",
     "label": "K-676",
     "name": "Ballet Slippers"
   },
   {
-    "hex": " #fecbd2 ",
+    "hex": "#fecbd2 ",
     "label": "K-677",
     "name": "Calique"
   },
   {
-    "hex": " #fedce1 ",
+    "hex": "#fedce1 ",
     "label": "K-678",
     "name": "Sweet Memories"
   },
   {
-    "hex": " #fce5e7 ",
+    "hex": "#fce5e7 ",
     "label": "K-679",
     "name": "Pink Mist"
   },
   {
-    "hex": " #cf252b ",
+    "hex": "#cf252b ",
     "label": "K-680",
     "name": "Painter's Red"
   },
   {
-    "hex": " #f2728a ",
+    "hex": "#f2728a ",
     "label": "K-681",
     "name": "P.J.'s"
   },
   {
-    "hex": " #f88fa7 ",
+    "hex": "#f88fa7 ",
     "label": "K-682",
     "name": "Pink Posey"
   },
   {
-    "hex": " #feafc2 ",
+    "hex": "#feafc2 ",
     "label": "K-683",
     "name": "Climbing Rose"
   },
   {
-    "hex": " #ffc2d0 ",
+    "hex": "#ffc2d0 ",
     "label": "K-684",
     "name": "Chenille Spread"
   },
   {
-    "hex": " #ffd6de ",
+    "hex": "#ffd6de ",
     "label": "K-685",
     "name": "Fuzzy Slippers"
   },
   {
-    "hex": " #fce4e7 ",
+    "hex": "#fce4e7 ",
     "label": "K-686",
     "name": "Beth's Smile"
   },
   {
-    "hex": " #f9efed ",
+    "hex": "#f9efed ",
     "label": "K-687",
     "name": "Winged Angel"
   },
   {
-    "hex": " #7f3e42 ",
+    "hex": "#7f3e42 ",
     "label": "K-688",
     "name": "Prado Red"
   },
   {
-    "hex": " #a76567 ",
+    "hex": "#a76567 ",
     "label": "K-689",
     "name": "Rose Queen"
   },
   {
-    "hex": " #b47477 ",
+    "hex": "#b47477 ",
     "label": "K-690",
     "name": "Mauve Medley"
   },
   {
-    "hex": " #ca9499 ",
+    "hex": "#ca9499 ",
     "label": "K-691",
     "name": "Vintage Rose"
   },
   {
-    "hex": " #daabb1 ",
+    "hex": "#daabb1 ",
     "label": "K-692",
     "name": "Spring Cheer"
   },
   {
-    "hex": " #eac0c3 ",
+    "hex": "#eac0c3 ",
     "label": "K-693",
     "name": "Minute Mauve"
   },
   {
-    "hex": " #f3d7d8 ",
+    "hex": "#f3d7d8 ",
     "label": "K-694",
     "name": "Berry Good"
   },
   {
-    "hex": " #f5e7e4 ",
+    "hex": "#f5e7e4 ",
     "label": "K-695",
     "name": "Pale Petals"
   },
   {
-    "hex": " #813545 ",
+    "hex": "#813545 ",
     "label": "K-696",
     "name": "Fine Wine "
   },
   {
-    "hex": " #b66972 ",
+    "hex": "#b66972 ",
     "label": "K-697",
     "name": "Wild Berry"
   },
   {
-    "hex": " #c87f87 ",
+    "hex": "#c87f87 ",
     "label": "K-698",
     "name": "Melita"
   },
   {
-    "hex": " #d28e9a ",
+    "hex": "#d28e9a ",
     "label": "K-699",
     "name": "Wild Scottish Rose"
   },
   {
-    "hex": " #e6aeb6 ",
+    "hex": "#e6aeb6 ",
     "label": "K-700",
     "name": "Sweet Heart"
   },
   {
-    "hex": " #f2c6cb ",
+    "hex": "#f2c6cb ",
     "label": "K-701",
     "name": "Briar Rose"
   },
   {
-    "hex": " #f8dcde ",
+    "hex": "#f8dcde ",
     "label": "K-702",
     "name": "Primrose Cottage"
   },
   {
-    "hex": " #f8ecea ",
+    "hex": "#f8ecea ",
     "label": "K-703",
     "name": "Blush of Spring"
   },
   {
-    "hex": " #a0293d ",
+    "hex": "#a0293d ",
     "label": "K-704",
     "name": "Jay's New Toy"
   },
   {
-    "hex": " #be5e6b ",
+    "hex": "#be5e6b ",
     "label": "K-705",
     "name": "Lipstick Pink"
   },
   {
-    "hex": " #da8c9b ",
+    "hex": "#da8c9b ",
     "label": "K-706",
     "name": "Rosey Bouquet"
   },
   {
-    "hex": " #e4a0ae ",
+    "hex": "#e4a0ae ",
     "label": "K-707",
     "name": "Susan's Smile"
   },
   {
-    "hex": " #f1b7c3 ",
+    "hex": "#f1b7c3 ",
     "label": "K-708",
     "name": "Party Pink"
   },
   {
-    "hex": " #f5c6cf ",
+    "hex": "#f5c6cf ",
     "label": "K-709",
     "name": "Blossom Beauty"
   },
   {
-    "hex": " #f7d5da ",
+    "hex": "#f7d5da ",
     "label": "K-710",
     "name": "Go Girl!"
   },
   {
-    "hex": " #f7e0e3 ",
+    "hex": "#f7e0e3 ",
     "label": "K-711",
     "name": "Sweet Illusions"
   },
   {
-    "hex": " #9f253d ",
+    "hex": "#9f253d ",
     "label": "K-712",
     "name": "Francesca"
   },
   {
-    "hex": " #e06793 ",
+    "hex": "#e06793 ",
     "label": "K-713",
     "name": "Rich Desires"
   },
   {
-    "hex": " #ed8db5 ",
+    "hex": "#ed8db5 ",
     "label": "K-714",
     "name": "Karen's Kiss"
   },
   {
-    "hex": " #f5afcb ",
+    "hex": "#f5afcb ",
     "label": "K-715",
     "name": "Budding Rose"
   },
   {
-    "hex": " #f9bfd7 ",
+    "hex": "#f9bfd7 ",
     "label": "K-716",
     "name": "Josie's Joy"
   },
   {
-    "hex": " #fad3e2 ",
+    "hex": "#fad3e2 ",
     "label": "K-717",
     "name": "Rose Rhapsody"
   },
   {
-    "hex": " #fbdee7 ",
+    "hex": "#fbdee7 ",
     "label": "K-718",
     "name": "First Dawn"
   },
   {
-    "hex": " #f9ebed ",
+    "hex": "#f9ebed ",
     "label": "K-719",
     "name": "Pale Blush"
   },
   {
-    "hex": " #932944 ",
+    "hex": "#932944 ",
     "label": "K-720",
     "name": "It's the Berries"
   },
   {
-    "hex": " #bb6b8c ",
+    "hex": "#bb6b8c ",
     "label": "K-721",
     "name": "Raisa"
   },
   {
-    "hex": " #d993b1 ",
+    "hex": "#d993b1 ",
     "label": "K-722",
     "name": "Euphoric Rose"
   },
   {
-    "hex": " #e3aec5 ",
+    "hex": "#e3aec5 ",
     "label": "K-723",
     "name": "Baby Yourself"
   },
   {
-    "hex": " #f5c0d3 ",
+    "hex": "#f5c0d3 ",
     "label": "K-724",
     "name": "Rose Camilla"
   },
   {
-    "hex": " #f7d1de ",
+    "hex": "#f7d1de ",
     "label": "K-725",
     "name": "Baby Blush"
   },
   {
-    "hex": " #f8dee6 ",
+    "hex": "#f8dee6 ",
     "label": "K-726",
     "name": "Sweet Roses"
   },
   {
-    "hex": " #f9eeee ",
+    "hex": "#f9eeee ",
     "label": "K-727",
     "name": "Pink Ice"
   },
   {
-    "hex": " #863a5e ",
+    "hex": "#863a5e ",
     "label": "K-728",
     "name": "Fine Burgundy"
   },
   {
-    "hex": " #b97093 ",
+    "hex": "#b97093 ",
     "label": "K-729",
     "name": "The Marquis"
   },
   {
-    "hex": " #c582a3 ",
+    "hex": "#c582a3 ",
     "label": "K-730",
     "name": "Santa Rosa"
   },
   {
-    "hex": " #ddaac5 ",
+    "hex": "#ddaac5 ",
     "label": "K-731",
     "name": "Heirloom Rose"
   },
   {
-    "hex": " #edc2d7 ",
+    "hex": "#edc2d7 ",
     "label": "K-732",
     "name": "Roses in the Snow"
   },
   {
-    "hex": " #f1d0de ",
+    "hex": "#f1d0de ",
     "label": "K-733",
     "name": "Smidgen of Cloud"
   },
   {
-    "hex": " #f5dee6 ",
+    "hex": "#f5dee6 ",
     "label": "K-734",
     "name": "Sheridan"
   },
   {
-    "hex": " #f7e8ec ",
+    "hex": "#f7e8ec ",
     "label": "K-735",
     "name": "Prettiest Pale"
   },
   {
-    "hex": " #6b3450 ",
+    "hex": "#6b3450 ",
     "label": "K-736",
     "name": "Country Cranberry"
   },
   {
-    "hex": " #b66da4 ",
+    "hex": "#b66da4 ",
     "label": "K-737",
     "name": "Earth Fired Red"
   },
   {
-    "hex": " #ce94c3 ",
+    "hex": "#ce94c3 ",
     "label": "K-738",
     "name": "Autumn Sedum"
   },
   {
-    "hex": " #dba8d1 ",
+    "hex": "#dba8d1 ",
     "label": "K-739",
     "name": "French Rose"
   },
   {
-    "hex": " #ebbfdf ",
+    "hex": "#ebbfdf ",
     "label": "K-740",
     "name": "Rosarian"
   },
   {
-    "hex": " #efc9e3 ",
+    "hex": "#efc9e3 ",
     "label": "K-741",
     "name": "Cabbage Rose"
   },
   {
-    "hex": " #f4d9eb ",
+    "hex": "#f4d9eb ",
     "label": "K-742",
     "name": "Spring Petals"
   },
   {
-    "hex": " #f4e3ec ",
+    "hex": "#f4e3ec ",
     "label": "K-743",
     "name": "Rosy View"
   },
   {
-    "hex": " #513249 ",
+    "hex": "#513249 ",
     "label": "K-744",
     "name": "So Merlot"
   },
   {
-    "hex": " #87657a ",
+    "hex": "#87657a ",
     "label": "K-745",
     "name": "Orchard Plum"
   },
   {
-    "hex": " #92778a ",
+    "hex": "#92778a ",
     "label": "K-746",
     "name": "Beguiling Blossom"
   },
   {
-    "hex": " #a48b9f ",
+    "hex": "#a48b9f ",
     "label": "K-747",
     "name": "Lady Like"
   },
   {
-    "hex": " #c1acbb ",
+    "hex": "#c1acbb ",
     "label": "K-748",
     "name": "Light Rosa"
   },
   {
-    "hex": " #d7bfcb ",
+    "hex": "#d7bfcb ",
     "label": "K-749",
     "name": "Pink Peace"
   },
   {
-    "hex": " #ead9de ",
+    "hex": "#ead9de ",
     "label": "K-750",
     "name": "Sweet and Sassy"
   },
   {
-    "hex": " #f4edec ",
+    "hex": "#f4edec ",
     "label": "K-751",
     "name": "Daybreak Mood"
   },
   {
-    "hex": " #513b4b ",
+    "hex": "#513b4b ",
     "label": "K-752",
     "name": "Autumn Plum"
   },
   {
-    "hex": " #7f6e78 ",
+    "hex": "#7f6e78 ",
     "label": "K-753",
     "name": "Lady Carlyle"
   },
   {
-    "hex": " #94838d ",
+    "hex": "#94838d ",
     "label": "K-754",
     "name": "Rosabella"
   },
   {
-    "hex": " #a495a1 ",
+    "hex": "#a495a1 ",
     "label": "K-755",
     "name": "Lida Rose"
   },
   {
-    "hex": " #c1b4bd ",
+    "hex": "#c1b4bd ",
     "label": "K-756",
     "name": "Apple Blossom Time"
   },
   {
-    "hex": " #d6c7cc ",
+    "hex": "#d6c7cc ",
     "label": "K-757",
     "name": "Pretty Princess"
   },
   {
-    "hex": " #e8ddde ",
+    "hex": "#e8ddde ",
     "label": "K-758",
     "name": "Placid Pink"
   },
   {
-    "hex": " #eee7e6 ",
+    "hex": "#eee7e6 ",
     "label": "K-759",
     "name": "Magical Mourn"
   },
   {
-    "hex": " #3f343a ",
+    "hex": "#3f343a ",
     "label": "K-760",
     "name": "Dark Berry"
   },
   {
-    "hex": " #7b6e73 ",
+    "hex": "#7b6e73 ",
     "label": "K-761",
     "name": "Plum Island"
   },
   {
-    "hex": " #93878b ",
+    "hex": "#93878b ",
     "label": "K-762",
     "name": "Lavender Rose"
   },
   {
-    "hex": " #aea4a9 ",
+    "hex": "#aea4a9 ",
     "label": "K-763",
     "name": "Heather Ridge"
   },
   {
-    "hex": " #beb5b9 ",
+    "hex": "#beb5b9 ",
     "label": "K-764",
     "name": "Romantic Light"
   },
   {
-    "hex": " #d3c8c9 ",
+    "hex": "#d3c8c9 ",
     "label": "K-765",
     "name": "Easter Egg"
   },
   {
-    "hex": " #e0d7d7 ",
+    "hex": "#e0d7d7 ",
     "label": "K-766",
     "name": "Plum Proud"
   },
   {
-    "hex": " #ece6e3 ",
+    "hex": "#ece6e3 ",
     "label": "K-767",
     "name": "Grape Expectations"
   },
   {
-    "hex": " #433c3c ",
+    "hex": "#433c3c ",
     "label": "K-768",
     "name": "Evening Empress"
   },
   {
-    "hex": " #5d585b ",
+    "hex": "#5d585b ",
     "label": "K-769",
     "name": "Zuli"
   },
   {
-    "hex": " #6f6b6f ",
+    "hex": "#6f6b6f ",
     "label": "K-770",
     "name": "Last Light"
   },
   {
-    "hex": " #87868b ",
+    "hex": "#87868b ",
     "label": "K-771",
     "name": "Girgitta"
   },
   {
-    "hex": " #a3a1a5 ",
+    "hex": "#a3a1a5 ",
     "label": "K-772",
     "name": "Heather Harmony"
   },
   {
-    "hex": " #bbb7b8 ",
+    "hex": "#bbb7b8 ",
     "label": "K-773",
     "name": "Pashmina"
   },
   {
-    "hex": " #d9d7d6 ",
+    "hex": "#d9d7d6 ",
     "label": "K-774",
     "name": "Sweet Musette"
   },
   {
-    "hex": " #eae8e5 ",
+    "hex": "#eae8e5 ",
     "label": "K-775",
     "name": "Iced Silver"
   },
   {
-    "hex": " #36373c ",
+    "hex": "#36373c ",
     "label": "K-776",
     "name": "In the Dark"
   },
   {
-    "hex": " #5a5c64 ",
+    "hex": "#5a5c64 ",
     "label": "K-777",
     "name": "Five O'Clock Shadow"
   },
   {
-    "hex": " #6d7079 ",
+    "hex": "#6d7079 ",
     "label": "K-778",
     "name": "Gray Whale Cove"
   },
   {
-    "hex": " #7f848e ",
+    "hex": "#7f848e ",
     "label": "K-779",
     "name": "Shadow Mountain"
   },
   {
-    "hex": " #a3a7af ",
+    "hex": "#a3a7af ",
     "label": "K-780",
     "name": "Bethel Corner"
   },
   {
-    "hex": " #bbbbc0 ",
+    "hex": "#bbbbc0 ",
     "label": "K-781",
     "name": "October Sky"
   },
   {
-    "hex": " #d4d4d5 ",
+    "hex": "#d4d4d5 ",
     "label": "K-782",
     "name": "White Palace"
   },
   {
-    "hex": " #dfdedf ",
+    "hex": "#dfdedf ",
     "label": "K-783",
     "name": "Billowing Clouds"
   },
   {
-    "hex": " #282728 ",
+    "hex": "#282728 ",
     "label": "K-784",
     "name": "Kitty Kitty"
   },
   {
-    "hex": " #575d65 ",
+    "hex": "#575d65 ",
     "label": "K-785",
     "name": "Smokey Hearth"
   },
   {
-    "hex": " #6b727a ",
+    "hex": "#6b727a ",
     "label": "K-786",
     "name": "Made in the Shade"
   },
   {
-    "hex": " #959da5 ",
+    "hex": "#959da5 ",
     "label": "K-787",
     "name": "Madison Grey"
   },
   {
-    "hex": " #aeb3b8 ",
+    "hex": "#aeb3b8 ",
     "label": "K-788",
     "name": "Dolphin Dance"
   },
   {
-    "hex": " #caced0 ",
+    "hex": "#caced0 ",
     "label": "K-789",
     "name": "Where there is Smoke"
   },
   {
-    "hex": " #e3e5e4 ",
+    "hex": "#e3e5e4 ",
     "label": "K-790",
     "name": "Heirloom Silver"
   },
   {
-    "hex": " #f0f0eb ",
+    "hex": "#f0f0eb ",
     "label": "K-791",
     "name": "Mercury"
   },
   {
-    "hex": " #49484c ",
+    "hex": "#49484c ",
     "label": "K-792",
     "name": "New Uniform"
   },
   {
-    "hex": " #57626b ",
+    "hex": "#57626b ",
     "label": "K-793",
     "name": "Blue Lake"
   },
   {
-    "hex": " #646f79 ",
+    "hex": "#646f79 ",
     "label": "K-794",
     "name": "Romantic Mood"
   },
   {
-    "hex": " #748490 ",
+    "hex": "#748490 ",
     "label": "K-795",
     "name": "Mirador"
   },
   {
-    "hex": " #8e9ca6 ",
+    "hex": "#8e9ca6 ",
     "label": "K-796",
     "name": "Brookview"
   },
   {
-    "hex": " #a1b4bf ",
+    "hex": "#a1b4bf ",
     "label": "K-797",
     "name": "Bali Blue"
   },
   {
-    "hex": " #c2cdd2 ",
+    "hex": "#c2cdd2 ",
     "label": "K-798",
     "name": "Quiet Sentiment"
   },
   {
-    "hex": " #d9dee0 ",
+    "hex": "#d9dee0 ",
     "label": "K-799",
     "name": "Moonlight Blue"
   },
   {
-    "hex": " #313b45 ",
+    "hex": "#313b45 ",
     "label": "K-800",
     "name": "In the Navy"
   },
   {
-    "hex": " #495d6b ",
+    "hex": "#495d6b ",
     "label": "K-801",
     "name": "Blazing Sky"
   },
   {
-    "hex": " #6e8393 ",
+    "hex": "#6e8393 ",
     "label": "K-802",
     "name": "Tucker's Toy"
   },
   {
-    "hex": " #8da2b0 ",
+    "hex": "#8da2b0 ",
     "label": "K-803",
     "name": "Blue Horizon"
   },
   {
-    "hex": " #9fb4c1 ",
+    "hex": "#9fb4c1 ",
     "label": "K-804",
     "name": "Grand Bay"
   },
   {
-    "hex": " #b6c7d0 ",
+    "hex": "#b6c7d0 ",
     "label": "K-805",
     "name": "Sky's the Limit"
   },
   {
-    "hex": " #d0dade ",
+    "hex": "#d0dade ",
     "label": "K-806",
     "name": "Clear to See"
   },
   {
-    "hex": " #e3e8e8 ",
+    "hex": "#e3e8e8 ",
     "label": "K-807",
     "name": "Snippet of Blue"
   },
   {
-    "hex": " #383a39 ",
+    "hex": "#383a39 ",
     "label": "K-808",
     "name": "Contessa's Cape"
   },
   {
-    "hex": " #565b5d ",
+    "hex": "#565b5d ",
     "label": "K-809",
     "name": "Charcoal Shadow"
   },
   {
-    "hex": " #63686a ",
+    "hex": "#63686a ",
     "label": "K-810",
     "name": "Grafton Grey"
   },
   {
-    "hex": " #81878a ",
+    "hex": "#81878a ",
     "label": "K-811",
     "name": "Stone Age"
   },
   {
-    "hex": " #9ea4a6 ",
+    "hex": "#9ea4a6 ",
     "label": "K-812",
     "name": "Cold Steel"
   },
   {
-    "hex": " #babdbc ",
+    "hex": "#babdbc ",
     "label": "K-813",
     "name": "Prairie Smoke"
   },
   {
-    "hex": " #d0d3d1 ",
+    "hex": "#d0d3d1 ",
     "label": "K-814",
     "name": "Grey Mare"
   },
   {
-    "hex": " #e7e7e3 ",
+    "hex": "#e7e7e3 ",
     "label": "K-815",
     "name": "Quick Silver"
   },
   {
-    "hex": " #3c3731 ",
+    "hex": "#3c3731 ",
     "label": "K-816",
     "name": "Carbon Copy"
   },
   {
-    "hex": " #5f5d5a ",
+    "hex": "#5f5d5a ",
     "label": "K-817",
     "name": "Dark Shadows"
   },
   {
-    "hex": " #858483 ",
+    "hex": "#858483 ",
     "label": "K-818",
     "name": "Cast in Stone"
   },
   {
-    "hex": " #a1a1a0 ",
+    "hex": "#a1a1a0 ",
     "label": "K-819",
     "name": "Diamond Heights"
   },
   {
-    "hex": " #b8b7b2 ",
+    "hex": "#b8b7b2 ",
     "label": "K-820",
     "name": "Platinum Plate"
   },
   {
-    "hex": " #cac8c4 ",
+    "hex": "#cac8c4 ",
     "label": "K-821",
     "name": "Silver Queen"
   },
   {
-    "hex": " #d8d6d1 ",
+    "hex": "#d8d6d1 ",
     "label": "K-822",
     "name": "Ice Age"
   },
   {
-    "hex": " #e4e2dd ",
+    "hex": "#e4e2dd ",
     "label": "K-823",
     "name": "Snowflake Confetti"
   },
   {
-    "hex": " #42423e ",
+    "hex": "#42423e ",
     "label": "K-824",
     "name": "Opening Night"
   },
   {
-    "hex": " #5e5f5d ",
+    "hex": "#5e5f5d ",
     "label": "K-825",
     "name": "Great Graphite"
   },
   {
-    "hex": " #6e6f6d ",
+    "hex": "#6e6f6d ",
     "label": "K-826",
     "name": "Shadow Dance"
   },
   {
-    "hex": " #838584 ",
+    "hex": "#838584 ",
     "label": "K-827",
     "name": "Grey Matters"
   },
   {
-    "hex": " #a1a4a3 ",
+    "hex": "#a1a4a3 ",
     "label": "K-828",
     "name": "Titanic Grey"
   },
   {
-    "hex": " #bbbab6 ",
+    "hex": "#bbbab6 ",
     "label": "K-829",
     "name": "Zephyr"
   },
   {
-    "hex": " #cbcbc7 ",
+    "hex": "#cbcbc7 ",
     "label": "K-830",
     "name": "Fading Fog"
   },
   {
-    "hex": " #d8d8d4 ",
+    "hex": "#d8d8d4 ",
     "label": "K-831",
     "name": "Whispering Smoke"
   },
   {
-    "hex": " #3f4341 ",
+    "hex": "#3f4341 ",
     "label": "K-832",
     "name": "Midnight in the Tropics"
   },
   {
-    "hex": " #58615f ",
+    "hex": "#58615f ",
     "label": "K-833",
     "name": "Shady Place"
   },
   {
-    "hex": " #6a7271 ",
+    "hex": "#6a7271 ",
     "label": "K-834",
     "name": "Roman Stone"
   },
   {
-    "hex": " #7e8788 ",
+    "hex": "#7e8788 ",
     "label": "K-835",
     "name": "Gothic Grey"
   },
   {
-    "hex": " #9aa3a3 ",
+    "hex": "#9aa3a3 ",
     "label": "K-836",
     "name": "Raw Steel"
   },
   {
-    "hex": " #b2b9b6 ",
+    "hex": "#b2b9b6 ",
     "label": "K-837",
     "name": "Wintry Sky"
   },
   {
-    "hex": " #bfc5c0 ",
+    "hex": "#bfc5c0 ",
     "label": "K-838",
     "name": "Grey Mist"
   },
   {
-    "hex": " #dbded9 ",
+    "hex": "#dbded9 ",
     "label": "K-839",
     "name": "First Frost"
   },
   {
-    "hex": " #4a4b44 ",
+    "hex": "#4a4b44 ",
     "label": "K-840",
     "name": "Dark Moon"
   },
   {
-    "hex": " #60635b ",
+    "hex": "#60635b ",
     "label": "K-841",
     "name": "Castlemare"
   },
   {
-    "hex": " #6f726a ",
+    "hex": "#6f726a ",
     "label": "K-842",
     "name": "Burnished Pewter"
   },
   {
-    "hex": " #848882 ",
+    "hex": "#848882 ",
     "label": "K-843",
     "name": "Slippery Shale"
   },
   {
-    "hex": " #9b9f99 ",
+    "hex": "#9b9f99 ",
     "label": "K-844",
     "name": "Pussy Willow"
   },
   {
-    "hex": " #b9bab1 ",
+    "hex": "#b9bab1 ",
     "label": "K-845",
     "name": "Hi Ho Silver"
   },
   {
-    "hex": " #c6c7be ",
+    "hex": "#c6c7be ",
     "label": "K-846",
     "name": "Winter Way"
   },
   {
-    "hex": " #dcdcd4 ",
+    "hex": "#dcdcd4 ",
     "label": "K-847",
     "name": "Siberian Snowflake"
   },
   {
-    "hex": " #3a4040 ",
+    "hex": "#3a4040 ",
     "label": "K-848",
     "name": "Moonless Sky"
   },
   {
-    "hex": " #5d6b6b ",
+    "hex": "#5d6b6b ",
     "label": "K-849",
     "name": "Wrapped in Twilight"
   },
   {
-    "hex": " #6f7c7c ",
+    "hex": "#6f7c7c ",
     "label": "K-850",
     "name": "Rio Bravo"
   },
   {
-    "hex": " #859495 ",
+    "hex": "#859495 ",
     "label": "K-851",
     "name": "Pools of Blue"
   },
   {
-    "hex": " #a0adad ",
+    "hex": "#a0adad ",
     "label": "K-852",
     "name": "Waterby"
   },
   {
-    "hex": " #bcc7c3 ",
+    "hex": "#bcc7c3 ",
     "label": "K-853",
     "name": "Quiet Cove"
   },
   {
-    "hex": " #c7d1cd ",
+    "hex": "#c7d1cd ",
     "label": "K-854",
     "name": "Dancing Bubbles"
   },
   {
-    "hex": " #d7ddd9 ",
+    "hex": "#d7ddd9 ",
     "label": "K-855",
     "name": "Whispering Waterfall"
   },
   {
-    "hex": " #294344 ",
+    "hex": "#294344 ",
     "label": "K-856",
     "name": "Cape Royal"
   },
   {
-    "hex": " #5a716d ",
+    "hex": "#5a716d ",
     "label": "K-857",
     "name": "Under Water World"
   },
   {
-    "hex": " #7f9796 ",
+    "hex": "#7f9796 ",
     "label": "K-858",
     "name": "Forest Falls"
   },
   {
-    "hex": " #9fb4b2 ",
+    "hex": "#9fb4b2 ",
     "label": "K-859",
     "name": "Mystic Lake"
   },
   {
-    "hex": " #b1c6c1 ",
+    "hex": "#b1c6c1 ",
     "label": "K-860",
     "name": "Sea Dreams"
   },
   {
-    "hex": " #c4d6d0 ",
+    "hex": "#c4d6d0 ",
     "label": "K-861",
     "name": "Misty Harbor"
   },
   {
-    "hex": " #dce5e0 ",
+    "hex": "#dce5e0 ",
     "label": "K-862",
     "name": "Ocean Cliffs"
   },
   {
-    "hex": " #e8ece6 ",
+    "hex": "#e8ece6 ",
     "label": "K-863",
     "name": "Water Spirit"
   },
   {
-    "hex": " #495146 ",
+    "hex": "#495146 ",
     "label": "K-864",
     "name": "Opera Evening"
   },
   {
-    "hex": " #626f63 ",
+    "hex": "#626f63 ",
     "label": "K-865",
     "name": "Logan Lake"
   },
   {
-    "hex": " #768477 ",
+    "hex": "#768477 ",
     "label": "K-866",
     "name": "Green Shadow"
   },
   {
-    "hex": " #89978d ",
+    "hex": "#89978d ",
     "label": "K-867",
     "name": "River Rhythm"
   },
   {
-    "hex": " #a0ada3 ",
+    "hex": "#a0ada3 ",
     "label": "K-868",
     "name": "Artful Green"
   },
   {
-    "hex": " #bdc8bc ",
+    "hex": "#bdc8bc ",
     "label": "K-869",
     "name": "Rain Mist"
   },
   {
-    "hex": " #d7ded4 ",
+    "hex": "#d7ded4 ",
     "label": "K-870",
     "name": "London Fog"
   },
   {
-    "hex": " #ebede5 ",
+    "hex": "#ebede5 ",
     "label": "K-871",
     "name": "Spirit Wind"
   },
   {
-    "hex": " #515f44 ",
+    "hex": "#515f44 ",
     "label": "K-872",
     "name": "Glade Creek"
   },
   {
-    "hex": " #6c8064 ",
+    "hex": "#6c8064 ",
     "label": "K-873",
     "name": "Spruce Spring"
   },
   {
-    "hex": " #7b8e71 ",
+    "hex": "#7b8e71 ",
     "label": "K-874",
     "name": "Maine Mist"
   },
   {
-    "hex": " #92a58d ",
+    "hex": "#92a58d ",
     "label": "K-875",
     "name": "Green Silence"
   },
   {
-    "hex": " #a7b9a2 ",
+    "hex": "#a7b9a2 ",
     "label": "K-876",
     "name": "When Twilight Falls"
   },
   {
-    "hex": " #b9cbb4 ",
+    "hex": "#b9cbb4 ",
     "label": "K-877",
     "name": "Eucalyptus Leaf"
   },
   {
-    "hex": " #d1decc ",
+    "hex": "#d1decc ",
     "label": "K-878",
     "name": "Tudor Grove"
   },
   {
-    "hex": " #e7ece0 ",
+    "hex": "#e7ece0 ",
     "label": "K-879",
     "name": "Spinney Mountain"
   },
   {
-    "hex": " #505646 ",
+    "hex": "#505646 ",
     "label": "K-880",
     "name": "Irish Moss"
   },
   {
-    "hex": " #687060 ",
+    "hex": "#687060 ",
     "label": "K-881",
     "name": "Glen Ivy"
   },
   {
-    "hex": " #777f6e ",
+    "hex": "#777f6e ",
     "label": "K-882",
     "name": "Valley Vista"
   },
   {
-    "hex": " #858f80 ",
+    "hex": "#858f80 ",
     "label": "K-883",
     "name": "Majestic Evergreen"
   },
   {
-    "hex": " #a2ab9d ",
+    "hex": "#a2ab9d ",
     "label": "K-884",
     "name": "Hidden Ravine"
   },
   {
-    "hex": " #bcc4b5 ",
+    "hex": "#bcc4b5 ",
     "label": "K-885",
     "name": "Gardening Trend"
   },
   {
-    "hex": " #d0d6c8 ",
+    "hex": "#d0d6c8 ",
     "label": "K-886",
     "name": "Wild Grass"
   },
   {
-    "hex": " #dee2d6 ",
+    "hex": "#dee2d6 ",
     "label": "K-887",
     "name": "Ridgefield"
   },
   {
-    "hex": " #585c49 ",
+    "hex": "#585c49 ",
     "label": "K-888",
     "name": "Clearfield"
   },
   {
-    "hex": " #6c715e ",
+    "hex": "#6c715e ",
     "label": "K-889",
     "name": "Spring's Eve"
   },
   {
-    "hex": " #8c9280 ",
+    "hex": "#8c9280 ",
     "label": "K-890",
     "name": "Maid of the Mist"
   },
   {
-    "hex": " #969c8a ",
+    "hex": "#969c8a ",
     "label": "K-891",
     "name": "Pineview"
   },
   {
-    "hex": " #abb09e ",
+    "hex": "#abb09e ",
     "label": "K-892",
     "name": "Song of Nature"
   },
   {
-    "hex": " #c1c5b1 ",
+    "hex": "#c1c5b1 ",
     "label": "K-893",
     "name": "Fernwood"
   },
   {
-    "hex": " #cfd2c1 ",
+    "hex": "#cfd2c1 ",
     "label": "K-894",
     "name": "Vintage Find"
   },
   {
-    "hex": " #e6e7da ",
+    "hex": "#e6e7da ",
     "label": "K-895",
     "name": "Sage Tinged"
   },
   {
-    "hex": " #5a6045 ",
+    "hex": "#5a6045 ",
     "label": "K-896",
     "name": "Ladies' Night"
   },
   {
-    "hex": " #747d62 ",
+    "hex": "#747d62 ",
     "label": "K-897",
     "name": "Green Dusk"
   },
   {
-    "hex": " #878f73 ",
+    "hex": "#878f73 ",
     "label": "K-898",
     "name": "Port Alice"
   },
   {
-    "hex": " #9ea78f ",
+    "hex": "#9ea78f ",
     "label": "K-899",
     "name": "Woodland Waterfall"
   },
   {
-    "hex": " #b0b8a2 ",
+    "hex": "#b0b8a2 ",
     "label": "K-900",
     "name": "Dream Weaver"
   },
   {
-    "hex": " #c4ccb3 ",
+    "hex": "#c4ccb3 ",
     "label": "K-901",
     "name": "Water Magic"
   },
   {
-    "hex": " #dbe0ce ",
+    "hex": "#dbe0ce ",
     "label": "K-902",
     "name": "Mystical Mist"
   },
   {
-    "hex": " #edeee2 ",
+    "hex": "#edeee2 ",
     "label": "K-903",
     "name": "Glacier Valley"
   },
   {
-    "hex": " #616b49 ",
+    "hex": "#616b49 ",
     "label": "K-904",
     "name": "Evergreen Trail"
   },
   {
-    "hex": " #71805e ",
+    "hex": "#71805e ",
     "label": "K-905",
     "name": "Old Growth Forest"
   },
   {
-    "hex": " #808e6b ",
+    "hex": "#808e6b ",
     "label": "K-906",
     "name": "Buchanan Gardens"
   },
   {
-    "hex": " #8f9d80 ",
+    "hex": "#8f9d80 ",
     "label": "K-907",
     "name": "Silver Mound"
   },
   {
-    "hex": " #adb99e ",
+    "hex": "#adb99e ",
     "label": "K-908",
     "name": "Lamb's Ear"
   },
   {
-    "hex": " #c4d0b5 ",
+    "hex": "#c4d0b5 ",
     "label": "K-909",
     "name": "Foresta"
   },
   {
-    "hex": " #d0dac2 ",
+    "hex": "#d0dac2 ",
     "label": "K-910",
     "name": "Fraser Lake"
   },
   {
-    "hex": " #dfe5d3 ",
+    "hex": "#dfe5d3 ",
     "label": "K-911",
     "name": "Hyde Park"
   },
   {
-    "hex": " #595847 ",
+    "hex": "#595847 ",
     "label": "K-912",
     "name": "Fortune Leaves"
   },
   {
-    "hex": " #6c6b5a ",
+    "hex": "#6c6b5a ",
     "label": "K-913",
     "name": "Hampstead"
   },
   {
-    "hex": " #8b8c7d ",
+    "hex": "#8b8c7d ",
     "label": "K-914",
     "name": "French Clay"
   },
   {
-    "hex": " #989889 ",
+    "hex": "#989889 ",
     "label": "K-915",
     "name": "Rock Wall"
   },
   {
-    "hex": " #abac9d ",
+    "hex": "#abac9d ",
     "label": "K-916",
     "name": "Marble Quarry"
   },
   {
-    "hex": " #c4c2b1 ",
+    "hex": "#c4c2b1 ",
     "label": "K-917",
     "name": "Dillard"
   },
   {
-    "hex": " #dad8ca ",
+    "hex": "#dad8ca ",
     "label": "K-918",
     "name": "Wishing Star"
   },
   {
-    "hex": " #ebe9df ",
+    "hex": "#ebe9df ",
     "label": "K-919",
     "name": "Glacier Ridge"
   },
   {
-    "hex": " #4b4639 ",
+    "hex": "#4b4639 ",
     "label": "K-920",
     "name": "Bravo Brown"
   },
   {
-    "hex": " #6f6a5d ",
+    "hex": "#6f6a5d ",
     "label": "K-921",
     "name": "Rock of Ages"
   },
   {
-    "hex": " #787466 ",
+    "hex": "#787466 ",
     "label": "K-922",
     "name": "Rolling Stone"
   },
   {
-    "hex": " #8b897e ",
+    "hex": "#8b897e ",
     "label": "K-923",
     "name": "Garden Bench"
   },
   {
-    "hex": " #a9a79d ",
+    "hex": "#a9a79d ",
     "label": "K-924",
     "name": "Ashford"
   },
   {
-    "hex": " #c2bdb0 ",
+    "hex": "#c2bdb0 ",
     "label": "K-925",
     "name": "Silver Spree"
   },
   {
-    "hex": " #d8d4ca ",
+    "hex": "#d8d4ca ",
     "label": "K-926",
     "name": "Pewter Moon"
   },
   {
-    "hex": " #ebe8e0 ",
+    "hex": "#ebe8e0 ",
     "label": "K-927",
     "name": "White Delight"
   },
   {
-    "hex": " #5c5242 ",
+    "hex": "#5c5242 ",
     "label": "K-928",
     "name": "Pilot Rock"
   },
   {
-    "hex": " #6f675c ",
+    "hex": "#6f675c ",
     "label": "K-929",
     "name": "Castle Dale"
   },
   {
-    "hex": " #837b6f ",
+    "hex": "#837b6f ",
     "label": "K-930",
     "name": "Hidcote Manor"
   },
   {
-    "hex": " #948e85 ",
+    "hex": "#948e85 ",
     "label": "K-931",
     "name": "Granite Cliff"
   },
   {
-    "hex": " #b2a99e ",
+    "hex": "#b2a99e ",
     "label": "K-932",
     "name": "Zanzibar"
   },
   {
-    "hex": " #d5cdc0 ",
+    "hex": "#d5cdc0 ",
     "label": "K-933",
     "name": "Weathered White"
   },
   {
-    "hex": " #dfd9ce ",
+    "hex": "#dfd9ce ",
     "label": "K-934",
     "name": "Silver Plume"
   },
   {
-    "hex": " #f0eee5 ",
+    "hex": "#f0eee5 ",
     "label": "K-935",
     "name": "Sierra Blanca"
   },
   {
-    "hex": " #665847 ",
+    "hex": "#665847 ",
     "label": "K-936",
     "name": "Mocha Mousse"
   },
   {
-    "hex": " #7a6b57 ",
+    "hex": "#7a6b57 ",
     "label": "K-937",
     "name": "CrËme de Caramel"
   },
   {
-    "hex": " #998c7a ",
+    "hex": "#998c7a ",
     "label": "K-938",
     "name": "Tropical Tan"
   },
   {
-    "hex": " #b1a694 ",
+    "hex": "#b1a694 ",
     "label": "K-939",
     "name": "Bristol Beige"
   },
   {
-    "hex": " #cabca8 ",
+    "hex": "#cabca8 ",
     "label": "K-940",
     "name": "Bamboo Beach"
   },
   {
-    "hex": " #cec2af ",
+    "hex": "#cec2af ",
     "label": "K-941",
     "name": "Sail Cloth "
   },
   {
-    "hex": " #e1d9ca ",
+    "hex": "#e1d9ca ",
     "label": "K-942",
     "name": "Travertine Trail"
   },
   {
-    "hex": " #e8e2d6 ",
+    "hex": "#e8e2d6 ",
     "label": "K-943",
     "name": "Bridal Wreath"
   },
   {
-    "hex": " #615846 ",
+    "hex": "#615846 ",
     "label": "K-944",
     "name": "Stone Wall"
   },
   {
-    "hex": " #726959 ",
+    "hex": "#726959 ",
     "label": "K-945",
     "name": "Carlton Clay"
   },
   {
-    "hex": " #847b6a ",
+    "hex": "#847b6a ",
     "label": "K-946",
     "name": "Rockvale"
   },
   {
-    "hex": " #989081 ",
+    "hex": "#989081 ",
     "label": "K-947",
     "name": "Utility Wear"
   },
   {
-    "hex": " #b3ac9e ",
+    "hex": "#b3ac9e ",
     "label": "K-948",
     "name": "Homespun Linen"
   },
   {
-    "hex": " #cac1b1 ",
+    "hex": "#cac1b1 ",
     "label": "K-949",
     "name": "Star Light"
   },
   {
-    "hex": " #d8d0c2 ",
+    "hex": "#d8d0c2 ",
     "label": "K-950",
     "name": "Desert Palm"
   },
   {
-    "hex": " #e3dcd0 ",
+    "hex": "#e3dcd0 ",
     "label": "K-951",
     "name": "Savana Oaks"
   },
   {
-    "hex": " #50493b ",
+    "hex": "#50493b ",
     "label": "K-952",
     "name": "Norwegian Wood"
   },
   {
-    "hex": " #72695c ",
+    "hex": "#72695c ",
     "label": "K-953",
     "name": "Fair Fieldstone"
   },
   {
-    "hex": " #847b6d ",
+    "hex": "#847b6d ",
     "label": "K-954",
     "name": "Greyswood"
   },
   {
-    "hex": " #a8a196 ",
+    "hex": "#a8a196 ",
     "label": "K-955",
     "name": "Wild Mushroom"
   },
   {
-    "hex": " #c7bfb2 ",
+    "hex": "#c7bfb2 ",
     "label": "K-956",
     "name": "Apollodorous"
   },
   {
-    "hex": " #d3cbbf ",
+    "hex": "#d3cbbf ",
     "label": "K-957",
     "name": "Grey Ghost"
   },
   {
-    "hex": " #ded8ce ",
+    "hex": "#ded8ce ",
     "label": "K-958",
     "name": "Sierra Snow"
   },
   {
-    "hex": " #eae6de ",
+    "hex": "#eae6de ",
     "label": "K-959",
     "name": "White Now!"
   },
   {
-    "hex": " #726845 ",
+    "hex": "#726845 ",
     "label": "K-960",
     "name": "Woven Willow"
   },
   {
-    "hex": " #827d60 ",
+    "hex": "#827d60 ",
     "label": "K-961",
     "name": "Manchester Mood"
   },
   {
-    "hex": " #918b6e ",
+    "hex": "#918b6e ",
     "label": "K-962",
     "name": "Sandalwood Tan"
   },
   {
-    "hex": " #a19d84 ",
+    "hex": "#a19d84 ",
     "label": "K-963",
     "name": "Head for the Beach"
   },
   {
-    "hex": " #cbc5ab ",
+    "hex": "#cbc5ab ",
     "label": "K-964",
     "name": "Beach Bum"
   },
   {
-    "hex": " #d6d0b9 ",
+    "hex": "#d6d0b9 ",
     "label": "K-965",
     "name": "Sand Castle"
   },
   {
-    "hex": " #ebe8d9 ",
+    "hex": "#ebe8d9 ",
     "label": "K-966",
     "name": "Creamy Natural"
   },
   {
-    "hex": " #f2f0e6 ",
+    "hex": "#f2f0e6 ",
     "label": "K-967",
     "name": "Pale Face"
   },
   {
-    "hex": " #61543e ",
+    "hex": "#61543e ",
     "label": "K-968",
     "name": "Olive Grove"
   },
   {
-    "hex": " #928266 ",
+    "hex": "#928266 ",
     "label": "K-969",
     "name": "African Plain"
   },
   {
-    "hex": " #a19276 ",
+    "hex": "#a19276 ",
     "label": "K-970",
     "name": "Highland Grass"
   },
   {
-    "hex": " #b0a38c ",
+    "hex": "#b0a38c ",
     "label": "K-971",
     "name": "Westover Hills"
   },
   {
-    "hex": " #c8bda9 ",
+    "hex": "#c8bda9 ",
     "label": "K-972",
     "name": "Baja Beach"
   },
   {
-    "hex": " #e2d9c6 ",
+    "hex": "#e2d9c6 ",
     "label": "K-973",
     "name": "Bleached Burl"
   },
   {
-    "hex": " #e7e0d1 ",
+    "hex": "#e7e0d1 ",
     "label": "K-974",
     "name": "Meadow Day"
   },
   {
-    "hex": " #f0ebe0 ",
+    "hex": "#f0ebe0 ",
     "label": "K-975",
     "name": "Campiello"
   },
   {
-    "hex": " #8e7742 ",
+    "hex": "#8e7742 ",
     "label": "K-976",
     "name": "Brown Mountain"
   },
   {
-    "hex": " #a48d59 ",
+    "hex": "#a48d59 ",
     "label": "K-977",
     "name": "Sandhurst"
   },
   {
-    "hex": " #b29a67 ",
+    "hex": "#b29a67 ",
     "label": "K-978",
     "name": "Barefoot Beach"
   },
   {
-    "hex": " #beaa7d ",
+    "hex": "#beaa7d ",
     "label": "K-979",
     "name": "Happy Camper"
   },
   {
-    "hex": " #d2c098 ",
+    "hex": "#d2c098 ",
     "label": "K-980",
     "name": "Western Wear"
   },
   {
-    "hex": " #e2d1a9 ",
+    "hex": "#e2d1a9 ",
     "label": "K-981",
     "name": "Dustry Trail"
   },
   {
-    "hex": " #f0e6cb ",
+    "hex": "#f0e6cb ",
     "label": "K-982",
     "name": "Barely Dawn"
   },
   {
-    "hex": " #f3ecd8 ",
+    "hex": "#f3ecd8 ",
     "label": "K-983",
     "name": "Dover Tint"
   },
   {
-    "hex": " #826b42 ",
+    "hex": "#826b42 ",
     "label": "K-984",
     "name": "Cozy Cabin"
   },
   {
-    "hex": " #a0895c ",
+    "hex": "#a0895c ",
     "label": "K-985",
     "name": "Woodriff"
   },
   {
-    "hex": " #b39c6f ",
+    "hex": "#b39c6f ",
     "label": "K-986",
     "name": "Soft Moccasin"
   },
   {
-    "hex": " #bda882 ",
+    "hex": "#bda882 ",
     "label": "K-987",
     "name": "Serengeti Safari"
   },
   {
-    "hex": " #d3c2a0 ",
+    "hex": "#d3c2a0 ",
     "label": "K-988",
     "name": "Pale Portabella"
   },
   {
-    "hex": " #e2d3b2 ",
+    "hex": "#e2d3b2 ",
     "label": "K-989",
     "name": "Tropical Straw"
   },
   {
-    "hex": " #eee4cc ",
+    "hex": "#eee4cc ",
     "label": "K-990",
     "name": "Organic Cotton"
   },
   {
-    "hex": " #f2ead8 ",
+    "hex": "#f2ead8 ",
     "label": "K-991",
     "name": "Cottage White"
   },
   {
-    "hex": " #9b733c ",
+    "hex": "#9b733c ",
     "label": "K-992",
     "name": "Golden Mist"
   },
   {
-    "hex": " #b38c52 ",
+    "hex": "#b38c52 ",
     "label": "K-993",
     "name": "Golden Prairie"
   },
   {
-    "hex": " #bb955c ",
+    "hex": "#bb955c ",
     "label": "K-994",
     "name": "Sheer Exposure"
   },
   {
-    "hex": " #cca978 ",
+    "hex": "#cca978 ",
     "label": "K-995",
     "name": "Balsam Brown"
   },
   {
-    "hex": " #dec197 ",
+    "hex": "#dec197 ",
     "label": "K-996",
     "name": "Ferncliffe"
   },
   {
-    "hex": " #ecd3a9 ",
+    "hex": "#ecd3a9 ",
     "label": "K-997",
     "name": "Skin Light"
   },
   {
-    "hex": " #f2e1c1 ",
+    "hex": "#f2e1c1 ",
     "label": "K-998",
     "name": "Aged Parchment"
   },
   {
-    "hex": " #f4ead0 ",
+    "hex": "#f4ead0 ",
     "label": "K-999",
     "name": "Cloud of Cream"
   },
   {
-    "hex": " #91714a ",
+    "hex": "#91714a ",
     "label": "K-1000",
     "name": "Royal Crown"
   },
   {
-    "hex": " #a3855c ",
+    "hex": "#a3855c ",
     "label": "K-1001",
     "name": "Mexican Hills"
   },
   {
-    "hex": " #b5986e ",
+    "hex": "#b5986e ",
     "label": "K-1002",
     "name": "Gold Promise"
   },
   {
-    "hex": " #bfa37f ",
+    "hex": "#bfa37f ",
     "label": "K-1003",
     "name": "Victorian Gold"
   },
   {
-    "hex": " #d4be9f ",
+    "hex": "#d4be9f ",
     "label": "K-1004",
     "name": "Star of the Garden"
   },
   {
-    "hex": " #e3d1b1 ",
+    "hex": "#e3d1b1 ",
     "label": "K-1005",
     "name": "Simply Tan"
   },
   {
-    "hex": " #ecddc3 ",
+    "hex": "#ecddc3 ",
     "label": "K-1006",
     "name": "Limestone Ridge"
   },
   {
-    "hex": " #f0e5d0 ",
+    "hex": "#f0e5d0 ",
     "label": "K-1007",
     "name": "Golden Pastel"
   },
   {
-    "hex": " #906b42 ",
+    "hex": "#906b42 ",
     "label": "K-1008",
     "name": "Carmel Candy"
   },
   {
-    "hex": " #a27d56 ",
+    "hex": "#a27d56 ",
     "label": "K-1009",
     "name": "Caramel Mountain"
   },
   {
-    "hex": " #b08e67 ",
+    "hex": "#b08e67 ",
     "label": "K-1010",
     "name": "Tumble Tan"
   },
   {
-    "hex": " #bea17f ",
+    "hex": "#bea17f ",
     "label": "K-1011",
     "name": "Bernard Beach"
   },
   {
-    "hex": " #d3b798 ",
+    "hex": "#d3b798 ",
     "label": "K-1012",
     "name": "Washed Khaki"
   },
   {
-    "hex": " #e3cbac ",
+    "hex": "#e3cbac ",
     "label": "K-1013",
     "name": "Timothy Tan"
   },
   {
-    "hex": " #ebd9be ",
+    "hex": "#ebd9be ",
     "label": "K-1014",
     "name": "Stilwell Beige"
   },
   {
-    "hex": " #f2e5d1 ",
+    "hex": "#f2e5d1 ",
     "label": "K-1015",
     "name": "Oat Straw"
   },
   {
-    "hex": " #775b41 ",
+    "hex": "#775b41 ",
     "label": "K-1016",
     "name": "Latte Please"
   },
   {
-    "hex": " #886c53 ",
+    "hex": "#886c53 ",
     "label": "K-1017",
     "name": "Dig It"
   },
   {
-    "hex": " #a48c75 ",
+    "hex": "#a48c75 ",
     "label": "K-1018",
     "name": "Pocahontas"
   },
   {
-    "hex": " #bea893 ",
+    "hex": "#bea893 ",
     "label": "K-1019",
     "name": "Swiss Cream"
   },
   {
-    "hex": " #d4bea6 ",
+    "hex": "#d4bea6 ",
     "label": "K-1020",
     "name": "Rocio"
   },
   {
-    "hex": " #dcc7b1 ",
+    "hex": "#dcc7b1 ",
     "label": "K-1021",
     "name": "Heritage Hills"
   },
   {
-    "hex": " #e6d6c3 ",
+    "hex": "#e6d6c3 ",
     "label": "K-1022",
     "name": "Tender Tan"
   },
   {
-    "hex": " #ede0d1 ",
+    "hex": "#ede0d1 ",
     "label": "K-1023",
     "name": "Whisper of White"
   },
   {
-    "hex": " #9f6e41 ",
+    "hex": "#9f6e41 ",
     "label": "K-1024",
     "name": "Fallen Leaf"
   },
   {
-    "hex": " #ae8157 ",
+    "hex": "#ae8157 ",
     "label": "K-1025",
     "name": "African Desert"
   },
   {
-    "hex": " #cba37e ",
+    "hex": "#cba37e ",
     "label": "K-1026",
     "name": "Supreme Bean"
   },
   {
-    "hex": " #ddbc9b ",
+    "hex": "#ddbc9b ",
     "label": "K-1027",
     "name": "Brownstone"
   },
   {
-    "hex": " #ebcfad ",
+    "hex": "#ebcfad ",
     "label": "K-1028",
     "name": "Legato Lane"
   },
   {
-    "hex": " #eed6b8 ",
+    "hex": "#eed6b8 ",
     "label": "K-1029",
     "name": "Palace Hill "
   },
   {
-    "hex": " #f3e1c8 ",
+    "hex": "#f3e1c8 ",
     "label": "K-1030",
     "name": "Julesberg"
   },
   {
-    "hex": " #f5e8d5 ",
+    "hex": "#f5e8d5 ",
     "label": "K-1031",
     "name": "Navarro"
   },
   {
-    "hex": " #835d3d ",
+    "hex": "#835d3d ",
     "label": "K-1032",
     "name": "Pinecone Path"
   },
   {
-    "hex": " #a07959 ",
+    "hex": "#a07959 ",
     "label": "K-1033",
     "name": "Wildwood Bay"
   },
   {
-    "hex": " #b18b68 ",
+    "hex": "#b18b68 ",
     "label": "K-1034",
     "name": "Rustic Charm"
   },
   {
-    "hex": " #be9b7e ",
+    "hex": "#be9b7e ",
     "label": "K-1035",
     "name": "Earthy Tan"
   },
   {
-    "hex": " #d3b399 ",
+    "hex": "#d3b399 ",
     "label": "K-1036",
     "name": "Early Tan"
   },
   {
-    "hex": " #e7ceb3 ",
+    "hex": "#e7ceb3 ",
     "label": "K-1037",
     "name": "Regina Beach"
   },
   {
-    "hex": " #ebd6be ",
+    "hex": "#ebd6be ",
     "label": "K-1038",
     "name": "Dune Walk"
   },
   {
-    "hex": " #f3e8d8 ",
+    "hex": "#f3e8d8 ",
     "label": "K-1039",
     "name": "Sandollar Beach"
   },
   {
-    "hex": " #886144 ",
+    "hex": "#886144 ",
     "label": "K-1040",
     "name": "Mochaccino"
   },
   {
-    "hex": " #997354 ",
+    "hex": "#997354 ",
     "label": "K-1041",
     "name": "Burnished Caramel"
   },
   {
-    "hex": " #a68265 ",
+    "hex": "#a68265 ",
     "label": "K-1042",
     "name": "Benetello"
   },
   {
-    "hex": " #b39277 ",
+    "hex": "#b39277 ",
     "label": "K-1043",
     "name": "Country Life"
   },
   {
-    "hex": " #ceb097 ",
+    "hex": "#ceb097 ",
     "label": "K-1044",
     "name": "Soft Buckskin"
   },
   {
-    "hex": " #dfc4a9 ",
+    "hex": "#dfc4a9 ",
     "label": "K-1045",
     "name": "Sandunia"
   },
   {
-    "hex": " #e8d2bb ",
+    "hex": "#e8d2bb ",
     "label": "K-1046",
     "name": "Baked Biscuit"
   },
   {
-    "hex": " #f0e3d3 ",
+    "hex": "#f0e3d3 ",
     "label": "K-1047",
     "name": "Bare Bone"
   },
   {
-    "hex": " #7c5539 ",
+    "hex": "#7c5539 ",
     "label": "K-1048",
     "name": "Western Pursuit"
   },
   {
-    "hex": " #977055 ",
+    "hex": "#977055 ",
     "label": "K-1049",
     "name": "Maple Sugar"
   },
   {
-    "hex": " #a88266 ",
+    "hex": "#a88266 ",
     "label": "K-1050",
     "name": "Carmel Valley"
   },
   {
-    "hex": " #b18e76 ",
+    "hex": "#b18e76 ",
     "label": "K-1051",
     "name": "Sandy's Shores"
   },
   {
-    "hex": " #cbab95 ",
+    "hex": "#cbab95 ",
     "label": "K-1052",
     "name": "Sands of Time"
   },
   {
-    "hex": " #ddc0a8 ",
+    "hex": "#ddc0a8 ",
     "label": "K-1053",
     "name": "Big on Beige "
   },
   {
-    "hex": " #ebd7c4 ",
+    "hex": "#ebd7c4 ",
     "label": "K-1054",
     "name": "Fair Ivory"
   },
   {
-    "hex": " #f2e9dc ",
+    "hex": "#f2e9dc ",
     "label": "K-1055",
     "name": "Bare Essential"
   },
   {
-    "hex": " #a06339 ",
+    "hex": "#a06339 ",
     "label": "K-1056",
     "name": "Warrior King"
   },
   {
-    "hex": " #b57950 ",
+    "hex": "#b57950 ",
     "label": "K-1057",
     "name": "Chamois Shirt"
   },
   {
-    "hex": " #ce9771 ",
+    "hex": "#ce9771 ",
     "label": "K-1058",
     "name": "Vizcaino Desert"
   },
   {
-    "hex": " #e1b392 ",
+    "hex": "#e1b392 ",
     "label": "K-1059",
     "name": "Fresh Sawdust"
   },
   {
-    "hex": " #eec7a5 ",
+    "hex": "#eec7a5 ",
     "label": "K-1060",
     "name": "Beachville"
   },
   {
-    "hex": " #f1cfb0 ",
+    "hex": "#f1cfb0 ",
     "label": "K-1061",
     "name": "Taffy Surprise"
   },
   {
-    "hex": " #f5dbc1 ",
+    "hex": "#f5dbc1 ",
     "label": "K-1062",
     "name": "Beach Walk"
   },
   {
-    "hex": " #f6ebdb ",
+    "hex": "#f6ebdb ",
     "label": "K-1063",
     "name": "Crystal Beach"
   },
   {
-    "hex": " #714c3b ",
+    "hex": "#714c3b ",
     "label": "K-1064",
     "name": "Soul of the Earth"
   },
   {
-    "hex": " #a37255 ",
+    "hex": "#a37255 ",
     "label": "K-1065",
     "name": "Terrific Tan"
   },
   {
-    "hex": " #b58669 ",
+    "hex": "#b58669 ",
     "label": "K-1066",
     "name": "Brighton Beach"
   },
   {
-    "hex": " #c2977e ",
+    "hex": "#c2977e ",
     "label": "K-1067",
     "name": "Southwest Sand"
   },
   {
-    "hex": " #d1a992 ",
+    "hex": "#d1a992 ",
     "label": "K-1068",
     "name": "Beauty and the Beach"
   },
   {
-    "hex": " #e1bfa5 ",
+    "hex": "#e1bfa5 ",
     "label": "K-1069",
     "name": "Face of Innocence"
   },
   {
-    "hex": " #f0dbc8 ",
+    "hex": "#f0dbc8 ",
     "label": "K-1070",
     "name": "Sunwashed Beach"
   },
   {
-    "hex": " #f4e5d6 ",
+    "hex": "#f4e5d6 ",
     "label": "K-1071",
     "name": "Moongaze"
   },
   {
-    "hex": " #9f4d38 ",
+    "hex": "#9f4d38 ",
     "label": "K-1072",
     "name": "Truffle Trouble"
   },
   {
-    "hex": " #a96348 ",
+    "hex": "#a96348 ",
     "label": "K-1073",
     "name": "Rustic Hills"
   },
   {
-    "hex": " #c1816b ",
+    "hex": "#c1816b ",
     "label": "K-1074",
     "name": "Spice Island"
   },
   {
-    "hex": " #d8a08b ",
+    "hex": "#d8a08b ",
     "label": "K-1075",
     "name": "Copperfield"
   },
   {
-    "hex": " #e7b69e ",
+    "hex": "#e7b69e ",
     "label": "K-1076",
     "name": "Ancient Inca"
   },
   {
-    "hex": " #e9b9a3 ",
+    "hex": "#e9b9a3 ",
     "label": "K-1077",
     "name": "Doug's Dale"
   },
   {
-    "hex": " #f1ccb9 ",
+    "hex": "#f1ccb9 ",
     "label": "K-1078",
     "name": "Tangier Tan"
   },
   {
-    "hex": " #f6dfd0 ",
+    "hex": "#f6dfd0 ",
     "label": "K-1079",
     "name": "Mariah"
   },
   {
-    "hex": " #8a4e37 ",
+    "hex": "#8a4e37 ",
     "label": "K-1080",
     "name": "Old Brick"
   },
   {
-    "hex": " #a5644d ",
+    "hex": "#a5644d ",
     "label": "K-1081",
     "name": "Fox Wood"
   },
   {
-    "hex": " #b4745e ",
+    "hex": "#b4745e ",
     "label": "K-1082",
     "name": "Copper Coast"
   },
   {
-    "hex": " #cb9583 ",
+    "hex": "#cb9583 ",
     "label": "K-1083",
     "name": "Rustic Pottery"
   },
   {
-    "hex": " #d9a797 ",
+    "hex": "#d9a797 ",
     "label": "K-1084",
     "name": "Sunbaked Clay"
   },
   {
-    "hex": " #e6bba8 ",
+    "hex": "#e6bba8 ",
     "label": "K-1085",
     "name": "Wasaga Beach"
   },
   {
-    "hex": " #f2d4c5 ",
+    "hex": "#f2d4c5 ",
     "label": "K-1086",
     "name": "In the Buff"
   },
   {
-    "hex": " #f6e7dd ",
+    "hex": "#f6e7dd ",
     "label": "K-1087",
     "name": "Kensington"
   },
   {
-    "hex": " #8b3c2a ",
+    "hex": "#8b3c2a ",
     "label": "K-1088",
     "name": "Majestic Ridge"
   },
   {
-    "hex": " #af6049 ",
+    "hex": "#af6049 ",
     "label": "K-1089",
     "name": "Pebblestone Clay"
   },
   {
-    "hex": " #c57c69 ",
+    "hex": "#c57c69 ",
     "label": "K-1090",
     "name": "Prairie Island"
   },
   {
-    "hex": " #dc9886 ",
+    "hex": "#dc9886 ",
     "label": "K-1091",
     "name": "Rocky Cliff"
   },
   {
-    "hex": " #eaac96 ",
+    "hex": "#eaac96 ",
     "label": "K-1092",
     "name": "Timber Ridge"
   },
   {
-    "hex": " #f3c8b6 ",
+    "hex": "#f3c8b6 ",
     "label": "K-1093",
     "name": "Stoney Creek"
   },
   {
-    "hex": " #f8e0d4 ",
+    "hex": "#f8e0d4 ",
     "label": "K-1094",
     "name": "Fresh Air"
   },
   {
-    "hex": " #f6ede3 ",
+    "hex": "#f6ede3 ",
     "label": "K-1095",
     "name": "Abbey Lane"
   },
   {
-    "hex": " #693834 ",
+    "hex": "#693834 ",
     "label": "K-1096",
     "name": "Spice Variety"
   },
   {
-    "hex": " #935a4b ",
+    "hex": "#935a4b ",
     "label": "K-1097",
     "name": "Southwest Spirit"
   },
   {
-    "hex": " #a46c5d ",
+    "hex": "#a46c5d ",
     "label": "K-1098",
     "name": "Point Sienna"
   },
   {
-    "hex": " #c39388 ",
+    "hex": "#c39388 ",
     "label": "K-1099",
     "name": "Topaz Tease"
   },
   {
-    "hex": " #d7a99b ",
+    "hex": "#d7a99b ",
     "label": "K-1100",
     "name": "Warm Sands"
   },
   {
-    "hex": " #e2baae ",
+    "hex": "#e2baae ",
     "label": "K-1101",
     "name": "Parma"
   },
   {
-    "hex": " #eaccc0 ",
+    "hex": "#eaccc0 ",
     "label": "K-1102",
     "name": "Almond Kiss"
   },
   {
-    "hex": " #f1d9cf ",
+    "hex": "#f1d9cf ",
     "label": "K-1103",
     "name": "Bleached Ivory "
   },
   {
-    "hex": " #654737 ",
+    "hex": "#654737 ",
     "label": "K-1104",
     "name": "Bistro Brown"
   },
   {
-    "hex": " #7f5f51 ",
+    "hex": "#7f5f51 ",
     "label": "K-1105",
     "name": "Mocha Java"
   },
   {
-    "hex": " #997a6c ",
+    "hex": "#997a6c ",
     "label": "K-1106",
     "name": "Pale Palamino"
   },
   {
-    "hex": " #a88c81 ",
+    "hex": "#a88c81 ",
     "label": "K-1107",
     "name": "Reuben Ridge"
   },
   {
-    "hex": " #baa096 ",
+    "hex": "#baa096 ",
     "label": "K-1108",
     "name": "Stream Stone"
   },
   {
-    "hex": " #cfb6a9 ",
+    "hex": "#cfb6a9 ",
     "label": "K-1109",
     "name": "Sandstorm"
   },
   {
-    "hex": " #ddc6bb ",
+    "hex": "#ddc6bb ",
     "label": "K-1110",
     "name": "Beach Bound"
   },
   {
-    "hex": " #ece0d7 ",
+    "hex": "#ece0d7 ",
     "label": "K-1111",
     "name": "Beige Bluff"
   },
   {
-    "hex": " #523c32 ",
+    "hex": "#523c32 ",
     "label": "K-1112",
     "name": "Jeff's Java"
   },
   {
-    "hex": " #715a50 ",
+    "hex": "#715a50 ",
     "label": "K-1113",
     "name": "Light Roast"
   },
   {
-    "hex": " #8a7268 ",
+    "hex": "#8a7268 ",
     "label": "K-1114",
     "name": "Mocha CafÈ"
   },
   {
-    "hex": " #ac9992 ",
+    "hex": "#ac9992 ",
     "label": "K-1115",
     "name": "Open Road"
   },
   {
-    "hex": " #c2afa5 ",
+    "hex": "#c2afa5 ",
     "label": "K-1116",
     "name": "Dancing Deer"
   },
   {
-    "hex": " #cdbbb1 ",
+    "hex": "#cdbbb1 ",
     "label": "K-1117",
     "name": "Roanoke"
   },
   {
-    "hex": " #dbcbc2 ",
+    "hex": "#dbcbc2 ",
     "label": "K-1118",
     "name": "Pale Starlet"
   },
   {
-    "hex": " #ece1d9 ",
+    "hex": "#ece1d9 ",
     "label": "K-1119",
     "name": "Turkish Towel"
   },
   {
-    "hex": " #8a3d36 ",
+    "hex": "#8a3d36 ",
     "label": "K-1120",
     "name": "Autumn's Bronze"
   },
   {
-    "hex": " #a55144 ",
+    "hex": "#a55144 ",
     "label": "K-1121",
     "name": "Penny Lane"
   },
   {
-    "hex": " #b5665b ",
+    "hex": "#b5665b ",
     "label": "K-1122",
     "name": "Ginger Jar"
   },
   {
-    "hex": " #cf857b ",
+    "hex": "#cf857b ",
     "label": "K-1123",
     "name": "Cinnamon Rose"
   },
   {
-    "hex": " #ebada1 ",
+    "hex": "#ebada1 ",
     "label": "K-1124",
     "name": "Tuscan Trail"
   },
   {
-    "hex": " #f2bfb4 ",
+    "hex": "#f2bfb4 ",
     "label": "K-1125",
     "name": "Coral Bells"
   },
   {
-    "hex": " #f7d8ce ",
+    "hex": "#f7d8ce ",
     "label": "K-1126",
     "name": "Rogue Bluff"
   },
   {
-    "hex": " #f6e9e2 ",
+    "hex": "#f6e9e2 ",
     "label": "K-1127",
     "name": "Castleford"
   },
   {
-    "hex": " #682f34 ",
+    "hex": "#682f34 ",
     "label": "K-1128",
     "name": "Wendy Way"
   },
   {
-    "hex": " #825757 ",
+    "hex": "#825757 ",
     "label": "K-1129",
     "name": "Chocolate Cherry"
   },
   {
-    "hex": " #987475 ",
+    "hex": "#987475 ",
     "label": "K-1130",
     "name": "Roshen Ridge"
   },
   {
-    "hex": " #b59595 ",
+    "hex": "#b59595 ",
     "label": "K-1131",
     "name": "Taryn Hills"
   },
   {
-    "hex": " #ccaba9 ",
+    "hex": "#ccaba9 ",
     "label": "K-1132",
     "name": "Demetrio"
   },
   {
-    "hex": " #d9bebc ",
+    "hex": "#d9bebc ",
     "label": "K-1133",
     "name": "Chambord Charm"
   },
   {
-    "hex": " #e5cdca ",
+    "hex": "#e5cdca ",
     "label": "K-1134",
     "name": "Mohican Mist"
   },
   {
-    "hex": " #ecdbd8 ",
+    "hex": "#ecdbd8 ",
     "label": "K-1135",
     "name": "Soft Sunrise"
   },
   {
-    "hex": " #783c3f ",
+    "hex": "#783c3f ",
     "label": "K-1136",
     "name": "Cheerful Cherry"
   },
   {
-    "hex": " #8d6266 ",
+    "hex": "#8d6266 ",
     "label": "K-1137",
     "name": "Spring Bliss"
   },
   {
-    "hex": " #a77f87 ",
+    "hex": "#a77f87 ",
     "label": "K-1138",
     "name": "Darius Dawn"
   },
   {
-    "hex": " #c09da4 ",
+    "hex": "#c09da4 ",
     "label": "K-1139",
     "name": "Pampered Pink"
   },
   {
-    "hex": " #d6b2b6 ",
+    "hex": "#d6b2b6 ",
     "label": "K-1140",
     "name": "Spring Thing"
   },
   {
-    "hex": " #e1c4c6 ",
+    "hex": "#e1c4c6 ",
     "label": "K-1141",
     "name": "Think About It"
   },
   {
-    "hex": " #ecd7d7 ",
+    "hex": "#ecd7d7 ",
     "label": "K-1142",
     "name": "Prelude to Pink"
   },
   {
-    "hex": " #f1e2e1 ",
+    "hex": "#f1e2e1 ",
     "label": "K-1143",
     "name": "Pillow Talk"
   },
   {
-    "hex": " #723747 ",
+    "hex": "#723747 ",
     "label": "K-1144",
     "name": "Very Berry"
   },
   {
-    "hex": " #9f6a73 ",
+    "hex": "#9f6a73 ",
     "label": "K-1145",
     "name": "Rosey Glow"
   },
   {
-    "hex": " #b78792 ",
+    "hex": "#b78792 ",
     "label": "K-1146",
     "name": "Rose Antiqua"
   },
   {
-    "hex": " #d1a7b1 ",
+    "hex": "#d1a7b1 ",
     "label": "K-1147",
     "name": "Noah's Ark"
   },
   {
-    "hex": " #e4bcc3 ",
+    "hex": "#e4bcc3 ",
     "label": "K-1148",
     "name": "Laureate"
   },
   {
-    "hex": " #ebcacf ",
+    "hex": "#ebcacf ",
     "label": "K-1149",
     "name": "Spring Sprig"
   },
   {
-    "hex": " #f0d6d7 ",
+    "hex": "#f0d6d7 ",
     "label": "K-1150",
     "name": "Pearl Pink"
   },
   {
-    "hex": " #f4e1e1 ",
+    "hex": "#f4e1e1 ",
     "label": "K-1151",
     "name": "Arctic Lights"
   },
   {
-    "hex": " #794550 ",
+    "hex": "#794550 ",
     "label": "K-1152",
     "name": "Wine Country"
   },
   {
-    "hex": " #936168 ",
+    "hex": "#936168 ",
     "label": "K-1153",
     "name": "Mi Amor"
   },
   {
-    "hex": " #ad7f89 ",
+    "hex": "#ad7f89 ",
     "label": "K-1154",
     "name": "Merry Meredith"
   },
   {
-    "hex": " #c69fa7 ",
+    "hex": "#c69fa7 ",
     "label": "K-1155",
     "name": "Cosmos Kiss"
   },
   {
-    "hex": " #d6b3ba ",
+    "hex": "#d6b3ba ",
     "label": "K-1156",
     "name": "Shrub Rose"
   },
   {
-    "hex": " #dcbbc1 ",
+    "hex": "#dcbbc1 ",
     "label": "K-1157",
     "name": "Andrea's Anticipation"
   },
   {
-    "hex": " #ead2d7 ",
+    "hex": "#ead2d7 ",
     "label": "K-1158",
     "name": "Easterville"
   },
   {
-    "hex": " #f3e6e5 ",
+    "hex": "#f3e6e5 ",
     "label": "K-1159",
     "name": "Soft Shell"
   },
   {
-    "hex": " #553f39 ",
+    "hex": "#553f39 ",
     "label": "K-1160",
     "name": "Dame Margaret"
   },
   {
-    "hex": " #6c5652 ",
+    "hex": "#6c5652 ",
     "label": "K-1161",
     "name": "Powderhorn Manor"
   },
   {
-    "hex": " #857271 ",
+    "hex": "#857271 ",
     "label": "K-1162",
     "name": "Rave Raisin"
   },
   {
-    "hex": " #a49191 ",
+    "hex": "#a49191 ",
     "label": "K-1163",
     "name": "Luberon"
   },
   {
-    "hex": " #bda9a5 ",
+    "hex": "#bda9a5 ",
     "label": "K-1164",
     "name": "Toasted Rose"
   },
   {
-    "hex": " #cdbbb7 ",
+    "hex": "#cdbbb7 ",
     "label": "K-1165",
     "name": "Mauve Star"
   },
   {
-    "hex": " #dbccc7 ",
+    "hex": "#dbccc7 ",
     "label": "K-1166",
     "name": "Natalia"
   },
   {
-    "hex": " #ebe2df ",
+    "hex": "#ebe2df ",
     "label": "K-1167",
     "name": "Soothing Spring"
   },
   {
-    "hex": " #463730 ",
+    "hex": "#463730 ",
     "label": "K-1168",
     "name": "Wrightsford"
   },
   {
-    "hex": " #705f57 ",
+    "hex": "#705f57 ",
     "label": "K-1169",
     "name": "Mohawk Valley"
   },
   {
-    "hex": " #7d6b62 ",
+    "hex": "#7d6b62 ",
     "label": "K-1170",
     "name": "Toasted Taupe"
   },
   {
-    "hex": " #90817b ",
+    "hex": "#90817b ",
     "label": "K-1171",
     "name": "Utopia"
   },
   {
-    "hex": " #a99c96 ",
+    "hex": "#a99c96 ",
     "label": "K-1172",
     "name": "Gypsum Gap"
   },
   {
-    "hex": " #c5b7ad ",
+    "hex": "#c5b7ad ",
     "label": "K-1173",
     "name": "Castellina"
   },
   {
-    "hex": " #d4c8c0 ",
+    "hex": "#d4c8c0 ",
     "label": "K-1174",
     "name": "Avorio"
   },
   {
-    "hex": " #dfd5cd ",
+    "hex": "#dfd5cd ",
     "label": "K-1175",
     "name": "Miguel Angel"
   },
   {
-    "hex": " #5e4e3f ",
+    "hex": "#5e4e3f ",
     "label": "K-1176",
     "name": "Coffee Connoisseur"
   },
   {
-    "hex": " #736557 ",
+    "hex": "#736557 ",
     "label": "K-1177",
     "name": "Evening Shade"
   },
   {
-    "hex": " #88796b ",
+    "hex": "#88796b ",
     "label": "K-1178",
     "name": "Woodbridge"
   },
   {
-    "hex": " #978b80 ",
+    "hex": "#978b80 ",
     "label": "K-1179",
     "name": "Old English Castle"
   },
   {
-    "hex": " #b1a69b ",
+    "hex": "#b1a69b ",
     "label": "K-1180",
     "name": "Kelmscott"
   },
   {
-    "hex": " #c7bbad ",
+    "hex": "#c7bbad ",
     "label": "K-1181",
     "name": "Master Manuel"
   },
   {
-    "hex": " #dbd1c5 ",
+    "hex": "#dbd1c5 ",
     "label": "K-1182",
     "name": "Olympic Circle"
   },
   {
-    "hex": " #e8e2d9 ",
+    "hex": "#e8e2d9 ",
     "label": "K-1183",
     "name": "Lamb's Wool"
   },
   {
-    "hex": " #5f4a39 ",
+    "hex": "#5f4a39 ",
     "label": "K-1184",
     "name": "Shady Side"
   },
   {
-    "hex": " #7e6b5c ",
+    "hex": "#7e6b5c ",
     "label": "K-1185",
     "name": "Brown Town"
   },
   {
-    "hex": " #927f70 ",
+    "hex": "#927f70 ",
     "label": "K-1186",
     "name": "Java 'n Cream"
   },
   {
-    "hex": " #a29285 ",
+    "hex": "#a29285 ",
     "label": "K-1187",
     "name": "Faded Beige"
   },
   {
-    "hex": " #b4a599 ",
+    "hex": "#b4a599 ",
     "label": "K-1188",
     "name": "Taupe View"
   },
   {
-    "hex": " #cbbbac ",
+    "hex": "#cbbbac ",
     "label": "K-1189",
     "name": "Beige Rage"
   },
   {
-    "hex": " #ded3c7 ",
+    "hex": "#ded3c7 ",
     "label": "K-1190",
     "name": "Pink Fluff"
   },
   {
-    "hex": " #eee7de ",
+    "hex": "#eee7de ",
     "label": "K-1191",
     "name": "Mountain Peak"
   },
   {
-    "hex": " #604a38 ",
+    "hex": "#604a38 ",
     "label": "K-1192",
     "name": "Cranberry Craze"
   },
   {
-    "hex": " #7b6656 ",
+    "hex": "#7b6656 ",
     "label": "K-1193",
     "name": "Cameroon Bay"
   },
   {
-    "hex": " #988577 ",
+    "hex": "#988577 ",
     "label": "K-1194",
     "name": "Antigua Rose"
   },
   {
-    "hex": " #b19f91 ",
+    "hex": "#b19f91 ",
     "label": "K-1195",
     "name": "Ashbury"
   },
   {
-    "hex": " #c7b5a4 ",
+    "hex": "#c7b5a4 ",
     "label": "K-1196",
     "name": "Beach Party"
   },
   {
-    "hex": " #d5c6b7 ",
+    "hex": "#d5c6b7 ",
     "label": "K-1197",
     "name": "Walnut Cream"
   },
   {
-    "hex": " #e2d6c8 ",
+    "hex": "#e2d6c8 ",
     "label": "K-1198",
     "name": "Canton Cotton"
   },
   {
-    "hex": " #e9dfd4 ",
+    "hex": "#e9dfd4 ",
     "label": "K-1199",
     "name": "Southern Sand"
   },
   {
-    "hex": " #d9bb24 ",
+    "hex": "#d9bb24 ",
     "label": "K-1200",
     "name": "Cancun Gold"
   },
   {
-    "hex": " #d2b11d ",
+    "hex": "#d2b11d ",
     "label": "K-1201",
     "name": "Mustard Field"
   },
   {
-    "hex": " #eec400 ",
+    "hex": "#eec400 ",
     "label": "K-1202",
     "name": "Cha Cha"
   },
   {
-    "hex": " #fdd31d ",
+    "hex": "#fdd31d ",
     "label": "K-1203",
     "name": "Sporty Yellow"
   },
   {
-    "hex": " #ffcf00 ",
+    "hex": "#ffcf00 ",
     "label": "K-1204",
     "name": "Lemon Ole'"
   },
   {
-    "hex": " #bf9334 ",
+    "hex": "#bf9334 ",
     "label": "K-1205",
     "name": "End of the Rainbow"
   },
   {
-    "hex": " #da9e19 ",
+    "hex": "#da9e19 ",
     "label": "K-1206",
     "name": "Curry Flurry"
   },
   {
-    "hex": " #bf8d38 ",
+    "hex": "#bf8d38 ",
     "label": "K-1207",
     "name": "Gold Trinket"
   },
   {
-    "hex": " #ffb700 ",
+    "hex": "#ffb700 ",
     "label": "K-1208",
     "name": "Bright'n Shiny"
   },
   {
-    "hex": " #ffa521 ",
+    "hex": "#ffa521 ",
     "label": "K-1209",
     "name": "Gilded Vision"
   },
   {
-    "hex": " #f89026 ",
+    "hex": "#f89026 ",
     "label": "K-1210",
     "name": "Glorious Sunset"
   },
   {
-    "hex": " #e87931 ",
+    "hex": "#e87931 ",
     "label": "K-1211",
     "name": "Glowing Ember"
   },
   {
-    "hex": " #e3622f ",
+    "hex": "#e3622f ",
     "label": "K-1212",
     "name": "L'Orange"
   },
   {
-    "hex": " #f86f29 ",
+    "hex": "#f86f29 ",
     "label": "K-1213",
     "name": "Light My Fire"
   },
   {
-    "hex": " #e64e2b ",
+    "hex": "#e64e2b ",
     "label": "K-1214",
     "name": "Montana Dust"
   },
   {
-    "hex": " #aa4832 ",
+    "hex": "#aa4832 ",
     "label": "K-1215",
     "name": "High Society"
   },
   {
-    "hex": " #c44538 ",
+    "hex": "#c44538 ",
     "label": "K-1216",
     "name": "China Rouge"
   },
   {
-    "hex": " #a0392f ",
+    "hex": "#a0392f ",
     "label": "K-1217",
     "name": "Leaf Rust"
   },
   {
-    "hex": " #dd402e ",
+    "hex": "#dd402e ",
     "label": "K-1218",
     "name": "Boing!"
   },
   {
-    "hex": " #c4342d ",
+    "hex": "#c4342d ",
     "label": "K-1219",
     "name": "Red Red"
   },
   {
-    "hex": " #bd2e32 ",
+    "hex": "#bd2e32 ",
     "label": "K-1220",
     "name": "Lipstick Pencil"
   },
   {
-    "hex": " #c13d44 ",
+    "hex": "#c13d44 ",
     "label": "K-1221",
     "name": "Rosie O'Dell"
   },
   {
-    "hex": " #952d3a ",
+    "hex": "#952d3a ",
     "label": "K-1222",
     "name": "American Rose"
   },
   {
-    "hex": " #ab2e46 ",
+    "hex": "#ab2e46 ",
     "label": "K-1223",
     "name": "Red Alert"
   },
   {
-    "hex": " #a93851 ",
+    "hex": "#a93851 ",
     "label": "K-1224",
     "name": "Red Blush"
   },
   {
-    "hex": " #ae3d55 ",
+    "hex": "#ae3d55 ",
     "label": "K-1225",
     "name": "Merlot Magic"
   },
   {
-    "hex": " #64403f ",
+    "hex": "#64403f ",
     "label": "K-1226",
     "name": "Red Raisin"
   },
   {
-    "hex": " #6e3940 ",
+    "hex": "#6e3940 ",
     "label": "K-1227",
     "name": "Dark Cherry Tart"
   },
   {
-    "hex": " #803740 ",
+    "hex": "#803740 ",
     "label": "K-1228",
     "name": "Bright Burgundy"
   },
   {
-    "hex": " #80444c ",
+    "hex": "#80444c ",
     "label": "K-1229",
     "name": "Raspberry Crush"
   },
   {
-    "hex": " #933851 ",
+    "hex": "#933851 ",
     "label": "K-1230",
     "name": "Teahouse Rose"
   },
   {
-    "hex": " #ae3162 ",
+    "hex": "#ae3162 ",
     "label": "K-1231",
     "name": "Valentine's Kiss"
   },
   {
-    "hex": " #8e3155 ",
+    "hex": "#8e3155 ",
     "label": "K-1232",
     "name": "Dark Burgundy Wine"
   },
   {
-    "hex": " #593843 ",
+    "hex": "#593843 ",
     "label": "K-1233",
     "name": "Plumbago"
   },
   {
-    "hex": " #663149 ",
+    "hex": "#663149 ",
     "label": "K-1234",
     "name": "Cherry Bon Bon"
   },
   {
-    "hex": " #753656 ",
+    "hex": "#753656 ",
     "label": "K-1235",
     "name": "Gailberry"
   },
   {
-    "hex": " #8e3463 ",
+    "hex": "#8e3463 ",
     "label": "K-1236",
     "name": "Fools' Fuscia"
   },
   {
-    "hex": " #94437c ",
+    "hex": "#94437c ",
     "label": "K-1237",
     "name": "Grape Riot"
   },
   {
-    "hex": " #713b5e ",
+    "hex": "#713b5e ",
     "label": "K-1238",
     "name": "Lavender Suede"
   },
   {
-    "hex": " #693d67 ",
+    "hex": "#693d67 ",
     "label": "K-1239",
     "name": "Floral Paradise"
   },
   {
-    "hex": " #583b64 ",
+    "hex": "#583b64 ",
     "label": "K-1240",
     "name": "Passion's Plea"
   },
   {
-    "hex": " #394778 ",
+    "hex": "#394778 ",
     "label": "K-1241",
     "name": "Sailor's Eyes"
   },
   {
-    "hex": " #38405d ",
+    "hex": "#38405d ",
     "label": "K-1242",
     "name": "Royal Wave"
   },
   {
-    "hex": " #30466b ",
+    "hex": "#30466b ",
     "label": "K-1243",
     "name": "Midnight Interlude"
   },
   {
-    "hex": " #274b71 ",
+    "hex": "#274b71 ",
     "label": "K-1244",
     "name": "Inky Sea"
   },
   {
-    "hex": " #005488 ",
+    "hex": "#005488 ",
     "label": "K-1245",
     "name": "Wavy Navy"
   },
   {
-    "hex": " #006c92 ",
+    "hex": "#006c92 ",
     "label": "K-1246",
     "name": "Ahoy! Blue"
   },
   {
-    "hex": " #21526c ",
+    "hex": "#21526c ",
     "label": "K-1247",
     "name": "Teal Shadow"
   },
   {
-    "hex": " #006c80 ",
+    "hex": "#006c80 ",
     "label": "K-1248",
     "name": "Great Blue Green"
   },
   {
-    "hex": " #244954 ",
+    "hex": "#244954 ",
     "label": "K-1249",
     "name": "Sophisticated Teal"
   },
   {
-    "hex": " #245a61 ",
+    "hex": "#245a61 ",
     "label": "K-1250",
     "name": "Turquoise Ocean"
   },
   {
-    "hex": " #205258 ",
+    "hex": "#205258 ",
     "label": "K-1251",
     "name": "Deep Sea Dream"
   },
   {
-    "hex": " #305e51 ",
+    "hex": "#305e51 ",
     "label": "K-1252",
     "name": "Deep Loden Green"
   },
   {
-    "hex": " #386651 ",
+    "hex": "#386651 ",
     "label": "K-1253",
     "name": "Glory Green"
   },
   {
-    "hex": " #096845 ",
+    "hex": "#096845 ",
     "label": "K-1254",
     "name": "Emerald Lights"
   },
   {
-    "hex": " #0e7046 ",
+    "hex": "#0e7046 ",
     "label": "K-1255",
     "name": "Hill and Vale"
   },
   {
-    "hex": " #476849 ",
+    "hex": "#476849 ",
     "label": "K-1256",
     "name": "Shamrock Charm"
   },
   {
-    "hex": " #538742 ",
+    "hex": "#538742 ",
     "label": "K-1257",
     "name": "Fair Lady Kelly"
   },
   {
-    "hex": " #63b125 ",
+    "hex": "#63b125 ",
     "label": "K-1258",
     "name": "Lots of Lime"
   },
   {
-    "hex": " #6c8b44 ",
+    "hex": "#6c8b44 ",
     "label": "K-1259",
     "name": "Baby Sprout"
   },
   {
-    "hex": " #f5f2e6 ",
+    "hex": "#f5f2e6 ",
     "label": "K-1260",
     "name": "Swan Wing"
   },
   {
-    "hex": " #f5f2e8 ",
+    "hex": "#f5f2e8 ",
     "label": "K-1261",
     "name": "Genna"
   },
   {
-    "hex": " #f6f3e9 ",
+    "hex": "#f6f3e9 ",
     "label": "K-1262",
     "name": "Beyond Pale"
   },
   {
-    "hex": " #f4f1ea ",
+    "hex": "#f4f1ea ",
     "label": "K-1263",
     "name": "Country Cotton"
   },
   {
-    "hex": " #f5f3ea ",
+    "hex": "#f5f3ea ",
     "label": "K-1264",
     "name": "Soap Suds"
   },
   {
-    "hex": " #f3f2ea ",
+    "hex": "#f3f2ea ",
     "label": "K-1265",
     "name": "Apple White"
   },
   {
-    "hex": " #f0ece8 ",
+    "hex": "#f0ece8 ",
     "label": "K-1266",
     "name": "Bridal Bouquet"
   },
   {
-    "hex": " #eceee9 ",
+    "hex": "#eceee9 ",
     "label": "K-1267",
     "name": "Birch Bay"
   },
   {
-    "hex": " #e8e9e1 ",
+    "hex": "#e8e9e1 ",
     "label": "K-1268",
     "name": "White Mountain"
   },
   {
-    "hex": " #edf2ec ",
+    "hex": "#edf2ec ",
     "label": "K-1269",
     "name": "Crystal Peak"
   },
   {
-    "hex": " #e6ede9 ",
+    "hex": "#e6ede9 ",
     "label": "K-1270",
     "name": "Sheer Ice"
   },
   {
-    "hex": " #edf4ec ",
+    "hex": "#edf4ec ",
     "label": "K-1271",
     "name": "White Echo"
   },
   {
-    "hex": " #e9f2ea ",
+    "hex": "#e9f2ea ",
     "label": "K-1272",
     "name": "Seagull Point"
   },
   {
-    "hex": " #e0f0ed ",
+    "hex": "#e0f0ed ",
     "label": "K-1273",
     "name": "Aqua Silence"
   },
   {
-    "hex": " #e2f0e8 ",
+    "hex": "#e2f0e8 ",
     "label": "K-1274",
     "name": "White Bisque"
   },
   {
-    "hex": " #e8f3e8 ",
+    "hex": "#e8f3e8 ",
     "label": "K-1275",
     "name": "Mint Taffy"
   },
   {
-    "hex": " #e8f2e8 ",
+    "hex": "#e8f2e8 ",
     "label": "K-1276",
     "name": "Aurora Splendor"
   },
   {
-    "hex": " #ecf2ea ",
+    "hex": "#ecf2ea ",
     "label": "K-1277",
     "name": "Waterfall Mist"
   },
   {
-    "hex": " #eef4ea ",
+    "hex": "#eef4ea ",
     "label": "K-1278",
     "name": "Elegant Satin"
   },
   {
-    "hex": " #eff3e6 ",
+    "hex": "#eff3e6 ",
     "label": "K-1279",
     "name": "Mint Essence"
   },
   {
-    "hex": " #f5f2e1 ",
+    "hex": "#f5f2e1 ",
     "label": "K-1280",
     "name": "Little Flower"
   },
   {
-    "hex": " #f4f2e6 ",
+    "hex": "#f4f2e6 ",
     "label": "K-1281",
     "name": "Pat O'Butter"
   },
   {
-    "hex": " #f5f1e4 ",
+    "hex": "#f5f1e4 ",
     "label": "K-1282",
     "name": "Angel Cloud"
   },
   {
-    "hex": " #f5f2e4 ",
+    "hex": "#f5f2e4 ",
     "label": "K-1283",
     "name": "Ivory Turret"
   },
   {
-    "hex": " #f8f3e3 ",
+    "hex": "#f8f3e3 ",
     "label": "K-1284",
     "name": "Amberling"
   },
   {
-    "hex": " #f9f3e1 ",
+    "hex": "#f9f3e1 ",
     "label": "K-1285",
     "name": "Almond Sugar"
   },
   {
-    "hex": " #efe8d4 ",
+    "hex": "#efe8d4 ",
     "label": "K-1286",
     "name": "Amazing Grace"
   },
   {
-    "hex": " #f1e8cd ",
+    "hex": "#f1e8cd ",
     "label": "K-1287",
     "name": "Homemade Biscuit"
   },
   {
-    "hex": " #e8dbc3 ",
+    "hex": "#e8dbc3 ",
     "label": "K-1288",
     "name": "Arizona Heat"
   },
   {
-    "hex": " #eee4cc ",
+    "hex": "#eee4cc ",
     "label": "K-1289",
     "name": "Milk Paint"
   },
   {
-    "hex": " #efe7d0 ",
+    "hex": "#efe7d0 ",
     "label": "K-1290",
     "name": "Lovely Lace"
   },
   {
-    "hex": " #f2ecda ",
+    "hex": "#f2ecda ",
     "label": "K-1291",
     "name": "Beige Daze"
   },
   {
-    "hex": " #f3edda ",
+    "hex": "#f3edda ",
     "label": "K-1292",
     "name": "Buff Bluff"
   },
   {
-    "hex": " #f3efe1 ",
+    "hex": "#f3efe1 ",
     "label": "K-1293",
     "name": "It's A Cream"
   },
   {
-    "hex": " #eae3d1 ",
+    "hex": "#eae3d1 ",
     "label": "K-1294",
     "name": "Dubai Sand"
   },
   {
-    "hex": " #f4eddf ",
+    "hex": "#f4eddf ",
     "label": "K-1295",
     "name": "Pebble Bluff"
   },
   {
-    "hex": " #ebe3d6 ",
+    "hex": "#ebe3d6 ",
     "label": "K-1296",
     "name": "Bare Necessity"
   },
   {
-    "hex": " #f6eee0 ",
+    "hex": "#f6eee0 ",
     "label": "K-1297",
     "name": "Apricot Blush"
   },
   {
-    "hex": " #faeee5 ",
+    "hex": "#faeee5 ",
     "label": "K-1298",
     "name": "Pinky"
   },
   {
-    "hex": " #f5f0e4 ",
+    "hex": "#f5f0e4 ",
     "label": "K-1299",
     "name": "Whitefair"
   },
   {
-    "hex": " #f7efe3 ",
+    "hex": "#f7efe3 ",
     "label": "K-1300",
     "name": "Sunbleached Shell"
   },
   {
-    "hex": " #f5eee7 ",
+    "hex": "#f5eee7 ",
     "label": "K-1301",
     "name": "Magic Mica"
   },
   {
-    "hex": " #f7f3e9 ",
+    "hex": "#f7f3e9 ",
     "label": "K-1302",
     "name": "Champagne Mist"
   },
   {
-    "hex": " #f7f2e8 ",
+    "hex": "#f7f2e8 ",
     "label": "K-1303",
     "name": "Barely There"
   },
   {
-    "hex": " #f7f1ea ",
+    "hex": "#f7f1ea ",
     "label": "K-1304",
     "name": "Victorian Cameo"
   },
   {
-    "hex": " #f7f3eb ",
+    "hex": "#f7f3eb ",
     "label": "K-1305",
     "name": "Palace Gown"
   },
   {
-    "hex": " #f3ede2 ",
+    "hex": "#f3ede2 ",
     "label": "K-1306",
     "name": "Neutral Ground"
   },
   {
-    "hex": " #f5f1e5 ",
+    "hex": "#f5f1e5 ",
     "label": "K-1307",
     "name": "Sandpiper Place"
   },
   {
-    "hex": " #f1eee2 ",
+    "hex": "#f1eee2 ",
     "label": "K-1308",
     "name": "Egg White"
   },
   {
-    "hex": " #f7f3e8 ",
+    "hex": "#f7f3e8 ",
     "label": "K-1309",
     "name": "Pressed Linen"
   },
   {
-    "hex": " #f4f0e5 ",
+    "hex": "#f4f0e5 ",
     "label": "K-1310",
     "name": "Beige Tower"
   },
   {
-    "hex": " #f7f5ec ",
+    "hex": "#f7f5ec ",
     "label": "K-1311",
     "name": "Cream Pie"
   },
   {
-    "hex": " #f1f0e5 ",
+    "hex": "#f1f0e5 ",
     "label": "K-1312",
     "name": "Pristine Linen"
   },
   {
-    "hex": " #f6f5ea ",
+    "hex": "#f6f5ea ",
     "label": "K-1313",
     "name": "Drifted Sand"
   },
   {
-    "hex": " #f7f5eb ",
+    "hex": "#f7f5eb ",
     "label": "K-1314",
     "name": "Pale Sisal"
   },
   {
-    "hex": " #f5f2e7 ",
+    "hex": "#f5f2e7 ",
     "label": "K-1315",
     "name": "Almost Ivory"
   },
   {
-    "hex": " #f1ede3 ",
+    "hex": "#f1ede3 ",
     "label": "K-1316",
     "name": "Papier Blanc"
   },
   {
-    "hex": " #f0ede3 ",
+    "hex": "#f0ede3 ",
     "label": "K-1317",
     "name": "White Silence"
   },
   {
-    "hex": " #eae6d9 ",
+    "hex": "#eae6d9 ",
     "label": "K-1318",
     "name": "Dream Nights"
   },
   {
-    "hex": " #eeeade ",
+    "hex": "#eeeade ",
     "label": "K-1319",
     "name": "Soft Sesame"
   }


### PR DESCRIPTION
Otherwise people have needed to use `.trim()` on these values.

Thanks for your amazing library!